### PR TITLE
COMP: Respect the include found by find_package

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -35,6 +35,7 @@ endif()
 
 if(USE_SYSTEM_ZLIB)
     find_package(ZLIB)
+    include_directories(BEFORE ${ZLIB_INCLUDE_DIRS} )
 endif()
 
 if(USE_SYSTEM_DB)


### PR DESCRIPTION
When using a custom build zlib with mangling, you MUST
use the zlib.h that is provided by the ZLIB_ROOT pathing.
