### PR TITLE
Create versioned symlinks on install to match autoconf python install.

### DIFF
--- a/cmake/python/CMakeLists.txt
+++ b/cmake/python/CMakeLists.txt
@@ -20,4 +20,8 @@ endif(BUILD_SHARED)
 # Export target
 set_property(GLOBAL APPEND PROPERTY PYTHON_TARGETS python)
 
+# Write the script that will create symlinks at install time.
+configure_file(InstallScript.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/InstallScript.cmake @ONLY)
+
 install(TARGETS python EXPORT PythonTargets RUNTIME DESTINATION ${BIN_INSTALL_DIR} COMPONENT Runtime)
+install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/InstallScript.cmake)

--- a/cmake/python/InstallScript.cmake.in
+++ b/cmake/python/InstallScript.cmake.in
@@ -1,0 +1,15 @@
+# This script creates the standard python<major-version>[.minor-version]
+# symlinks on unix at install time.
+
+if( UNIX )
+  message(STATUS "Creating Python executable symlinks...")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E create_symlink python 
+      python@PY_VERSION_MAJOR@
+    COMMAND ${CMAKE_COMMAND} -E create_symlink python
+      python@PY_VERSION_MAJOR@.@PY_VERSION_MINOR@
+    WORKING_DIRECTORY
+      @CMAKE_INSTALL_PREFIX@/@BIN_INSTALL_DIR@
+  )
+endif()
+


### PR DESCRIPTION
I added install hooks to create the usual python[major[.minor]] symlinks that the autoconf distribution uses. This lets this version work with CMake's usual FindPythonInterp find module, since it searches for versioned executables before searching for a generic 'python' executable.
