### PR TITLE
libffi: Avoid clash with builtin malloc and libc malloc

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -199,7 +199,6 @@ else(WIN32)
         #            _ctypes/callproc.c
         #            _ctypes/cfield.c
         #            _ctypes/libffi_osx/src/closures.c
-        #            _ctypes/libffi_osx/src/dlmalloc.c
         #            _ctypes/libffi_osx/${_libffi_system_dir}/ffi.c
         #            _ctypes/libffi_osx/${_libffi_system_dir}/ffi64.c
         #            _ctypes/libffi_osx/src/prep_cif.c
@@ -222,7 +221,6 @@ else(WIN32)
                     _ctypes/callproc.c
                     _ctypes/cfield.c
                     _ctypes/libffi/src/closures.c
-                    _ctypes/libffi/src/dlmalloc.c
                     _ctypes/libffi/src/prep_cif.c
                     _ctypes/stgdict.c
                     _ctypes/libffi/src/${_libffi_system_dir}/ffi.c


### PR DESCRIPTION
A different source file, closures.c, includes dlmalloc.c but sets
various preprocessor defines before doing so to make sure it's built
appropriately.  Building a seperate dlmalloc.c.o can possibly generate
incorectly defined and conflicting symbols.