### PR TITLE
Fix building on Windows

### DIFF
--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -195,8 +195,6 @@ elseif(WIN32)
     )
 endif(UNIX)
 
-set_property(SOURCE ${LIBPYTHON_SOURCES} APPEND PROPERTY COMPILE_DEFINITIONS Py_BUILD_CORE)
-
 # List of builtin extensions
 get_property(builtin_extensions GLOBAL PROPERTY builtin_extensions)
 
@@ -229,6 +227,12 @@ foreach(name ${builtin_extensions})
             APPEND PROPERTY COMPILE_DEFINITIONS ${extension_${name}_definitions})
     endif()
 endforeach()
+
+set_property(SOURCE ${LIBPYTHON_SOURCES} APPEND PROPERTY COMPILE_DEFINITIONS Py_BUILD_CORE)
+
+if(WIN32)
+set_property(SOURCE ${builtin_extension_sources} APPEND PROPERTY COMPILE_DEFINITIONS Py_BUILD_CORE)
+endif(WIN32)
 
 # Create the parts of config.c for platform-specific and user-controlled
 # builtin modules.


### PR DESCRIPTION
Following commit c6b4b6d5f31449449a3798fab2640aeaf1d0d544, building on Windows (Visual Studio 2013) gives the following error in Python.sln/libpython-shared.vcxproj:

    1>C:\dev\p\build\python-prefix\src\python\Modules\timemodule.c(1062): error C2491: '_PyTime_FloatTime' : definition of dllimport function not allowed

Defining Py_BUILD_CORE for just timemodule.c fixes the compile error, but then the following linker error occurs:

    1>LINK : fatal error LNK1104: cannot open file 'python27.lib'

This commit fixes the build by ensuring that, on Windows, Py_BUILD_CORE is defined for all files in the project.

Note that when BUILTIN_TESTCAPI is enabled I see the error described in c6b4b6d5f31449449a3798fab2640aeaf1d0d544. I found a reference to potential alternative fix: https://bugs.python.org/issue19348