### PR TITLE
Fix distutils.sysconfig._python_build() on windows

### DIFF
--- a/cmake/lib/CMakeLists.txt
+++ b/cmake/lib/CMakeLists.txt
@@ -27,14 +27,8 @@ foreach(file ${libfiles})
     endif(NOT is_platform_file OR is_matching_platform_file)
 endforeach(file)
 
-
-file(MAKE_DIRECTORY ${BIN_BUILD_DIR}/Modules)
-
 if(PY_VERSION VERSION_LESS "2.7.5")
   # Setup landmark allowing to run the interpreter from a build tree. See 'getpath.c' for details.
+  file(MAKE_DIRECTORY ${BIN_BUILD_DIR}/Modules)
   file(WRITE ${BIN_BUILD_DIR}/Modules/Setup "")
 endif()
-
-# See "is_python_build()" in sysconfig.py
-file(MAKE_DIRECTORY ${BIN_BUILD_DIR}/Modules)
-file(WRITE ${BIN_BUILD_DIR}/Modules/Setup.local "")

--- a/cmake/python/CMakeLists.txt
+++ b/cmake/python/CMakeLists.txt
@@ -22,6 +22,13 @@ set_property(GLOBAL APPEND PROPERTY PYTHON_TARGETS python)
 
 install(TARGETS python EXPORT PythonTargets RUNTIME DESTINATION ${BIN_INSTALL_DIR} COMPONENT Runtime)
 
+# See "is_python_build()" in sysconfig.py
+add_custom_command(TARGET python PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${BIN_BUILD_DIR}/${CMAKE_CFG_INTDIR}/Modules
+    COMMAND ${CMAKE_COMMAND} -E touch ${BIN_BUILD_DIR}/${CMAKE_CFG_INTDIR}/Modules/Setup.local
+    COMMENT "Creating '${BIN_INSTALL_DIR}/${CMAKE_CFG_INTDIR}/Modules/Setup.local'"
+    )
+
 if(UNIX AND PY_VERSION VERSION_GREATER "2.7.4")
     # Setup landmark allowing to run the interpreter from a build tree. See 'getpath.c' for details.
     add_custom_command(


### PR DESCRIPTION
Create 'Setup.local' accouting for multi-configuration build to ensure
'distutils.sysconfig.project_base' (used to check if python is
executed from a buildtree) is properly initialized.