### PR TITLE
Hide CMake policy CMP0042 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ endif()
 
 project(Python C ASM)
 
+if(POLICY CMP0042)
+    cmake_policy(SET CMP0042 OLD)
+endif()
+
 # Include helper functions
 include(cmake/CMakeChecks.cmake)
 include(cmake/Extensions.cmake)


### PR DESCRIPTION
CMake 3.0 introduced policy CMP0042 ("MACOSX_RPATH is enabled by default"). When building on OS X this results in warnings like:

    CMake Warning (dev):
      Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
      --help-policy CMP0042" for policy details.  Use the cmake_policy command to
      set the policy and suppress this warning.

      MACOSX_RPATH is not specified for the following targets:

       extension_array
       extension_audioop
       extension_binascii
    [...]

This commit hides those warnings.