### PR TITLE
Check build fails on MacOSX when build as shared with build_with_install_rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ include(CTest)
 
 # Options
 option(DOWNLOAD_SOURCES "Automatically download the Python sources" ON)
-option(BUILD_SHARED "Build a shared libpython library" OFF)
-option(BUILD_STATIC "Build a static libpython library" ON)
+option(BUILD_SHARED "Build a shared libpython library" ON)
+option(BUILD_STATIC "Build a static libpython library" OFF)
 option(BUILD_EXTENSIONS_AS_BUILTIN "Default all modules as builtin to libpython" OFF)
 option(USE_LIB64 "Search for dependencies and install to prefix/lib64 instead of prefix/lib" OFF)
 if(WIN32)


### PR DESCRIPTION
THIS COMMIT SHOUD NOT BE INTEGRATED INTO MASTER

The role of the commit is to confirm the build fail and will be effectively
fixed by PR #97.

It also test the feature introduced in 0f8541e9c42 teaching the driver
script how to extract additional CMake configuration arguments from the
commit message. This new feature provides a simple way to test some
options without having to explicitly change the CI build matrix.

This is special awesome comment:

[cmake -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON]