### PR TITLE
Fix openssl_md_meth_names error reported on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ branches:
   - master
   - /^ci.*$/
 
+addons:
+  apt:
+    packages:
+     - libssl-dev
+
 before_script:
  - wget -P /tmp/ https://raw.githubusercontent.com/davidsansome/python-cmake-buildsystem/dashboard/travis_dashboard.cmake
 


### PR DESCRIPTION
By updating the version of openssl used on travis, this commit fixes the
following error:

//----------
Traceback (most recent call last):
  File "/home/travis/build/python-cmake-buildsystem/python-cmake-buildsystem-build/lib/python2.7/test/regrtest.py", line 159, in <module>
    import random
  File "/home/travis/build/python-cmake-buildsystem/python-cmake-buildsystem-build/lib/python2.7/random.py", line 49, in <module>
    import hashlib as _hashlib
  File "/home/travis/build/python-cmake-buildsystem/python-cmake-buildsystem-build/lib/python2.7/hashlib.py", line 138, in <module>
    _hashlib.openssl_md_meth_names)
AttributeError: 'module' object has no attribute 'openssl_md_meth_names'
//----------

... caused when using the following options:

[cmake -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON;-DBUILD_SHARED=ON;-DBUILD_STATIC=OFF]