### PR TITLE
Fixed cmake error when BUILD_EXTENSIONS_AS_BUILTIN is enabled

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -445,7 +445,7 @@ add_python_extension(_decimal
     ${_decimal_LIBRARIES}
     ${_decimal_INCLUDEDIRS}
 )
-if(_decimal_compile_flags)
+if(_decimal_compile_flags AND NOT BUILTIN_DECIMAL)
     set_target_properties(extension_decimal PROPERTIES COMPILE_FLAGS ${_decimal_compile_flags})
 endif()
 
@@ -668,7 +668,7 @@ else()
     )
 endif()
 
-if(USE_LIBEDIT)
+if(USE_LIBEDIT AND NOT BUILTIN_READLINE)
     set_target_properties(extension_readline PROPERTIES
         COMPILE_DEFINITIONS "USE_LIBEDIT")
 endif()


### PR DESCRIPTION
Found this error when I was compiling Python 3 with extensions built in. This adds a guard to detect when the _decimal and readline extensions are built in, which doesn't create a separate target.