### PR TITLE
circle: Fix build renaming all image references

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,12 +38,12 @@ test:
   override:
 
     # Python 2.7.12
-    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts thewtex/cross-compiler-android-arm ctest -S /usr/scripts/circle_dashboard.cmake -VV
-    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts thewtex/cross-compiler-linux-armv6 ctest -S /usr/scripts/circle_dashboard.cmake -VV
-    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts thewtex/cross-compiler-linux-armv7 ctest -S /usr/scripts/circle_dashboard.cmake -VV
-    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts thewtex/cross-compiler-linux-ppc64le ctest -S /usr/scripts/circle_dashboard.cmake -VV
-    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts thewtex/cross-compiler-linux-x64 ctest -S /usr/scripts/circle_dashboard.cmake -VV
-    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts thewtex/cross-compiler-linux-x86 ctest -S /usr/scripts/circle_dashboard.cmake -VV
+    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts dockcross/android-arm ctest -S /usr/scripts/circle_dashboard.cmake -VV
+    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts dockcross/linux-armv6 ctest -S /usr/scripts/circle_dashboard.cmake -VV
+    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts dockcross/linux-armv7 ctest -S /usr/scripts/circle_dashboard.cmake -VV
+    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts dockcross/linux-ppc64le ctest -S /usr/scripts/circle_dashboard.cmake -VV
+    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts dockcross/linux-x64 ctest -S /usr/scripts/circle_dashboard.cmake -VV
+    - docker run --rm -e PY_VERSION=2.7.12 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts dockcross/linux-x86 ctest -S /usr/scripts/circle_dashboard.cmake -VV
 
     # Python 3.5.1
     - docker run --rm -e PY_VERSION=3.5.1 -e CIRCLE_SHA1 -e CIRCLE_PR_NUMBER -e CIRCLE_BRANCH -v ~/python-cmake-buildsystem:/usr/python-cmake-buildsystem:ro -v ~/scripts:/usr/scripts dockcross/android-arm ctest -S /usr/scripts/circle_dashboard.cmake -VV


### PR DESCRIPTION
This commit fixes a regression introduced in 9d43b16, it renames
remaining references to thewtex images.