### PR TITLE
Prevent a circular import when rebuilding Python under MS Windows.

### DIFF
--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -237,13 +237,10 @@ set(PYTHON_COMMON_SOURCES
     ${SRC_DIR}/Python/traceback.c
     ${SRC_DIR}/Python/_warnings.c
 )
+
 if(UNIX)
     list(APPEND PYTHON_COMMON_SOURCES
         ${SRC_DIR}/Python/frozenmain.c
-    )
-else()
-    list(APPEND PYTHON_COMMON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
     )
 endif()
 
@@ -371,10 +368,17 @@ endif()
 set(LIBPYTHON_FROZEN_SOURCES )
 if(IS_PY3)
 
+# Windows needs PyImport_FrozenModules declared...
+if(WIN32)
+  set(FROZENMODULES_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/frozenmodules.c)
+endif()
+
 # Build _freeze_importlib executable
+
 add_executable(_freeze_importlib
   ${SRC_DIR}/Programs/_freeze_importlib.c
   ${LIBPYTHON_OMIT_FROZEN_SOURCES}
+  ${FROZENMODULES_SOURCE}
   )
 target_link_libraries(_freeze_importlib ${LIBPYTHON_TARGET_LIBRARIES})
 
@@ -428,17 +432,14 @@ add_executable(pgen
 set(LIBPYTHON_SOURCES
     ${LIBPYTHON_OMIT_FROZEN_SOURCES}
     ${LIBPYTHON_FROZEN_SOURCES}
+    ${SRC_DIR}/Python/frozen.c
 )
-if(UNIX)
-    list(APPEND LIBPYTHON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
-    )
-endif()
 
 # Build python libraries
 function(add_libpython name type install component)
     add_library(${name} ${type} ${LIBPYTHON_SOURCES})
     target_link_libraries(${name} ${LIBPYTHON_TARGET_LIBRARIES})
+    add_dependencies(${name} freeze_modules)
 
     if(MSVC)
         # Explicitly disable COMDAT folding. Note that this was not required

--- a/cmake/libpython/frozenmodules.c
+++ b/cmake/libpython/frozenmodules.c
@@ -1,0 +1,9 @@
+/* Dummy frozen modules initializer for building _freeze_importlib
+   under MS Windows, as using the frozen.c from the Python
+   distribution results in a circular include of importlib.h
+*/
+
+#include <Python.h>
+#include <marshal.h>
+
+const struct _frozen *PyImport_FrozenModules;


### PR DESCRIPTION
An out-of-the-box build works since the Python distribution includes pre-built `importlib.h` and `importlib_external.h` files. These are however deleted as part of cleaning a build (e.g. `ninja clean`) and can not be rebuilt due to a circular dependency, and so subsequent build attempts fail. Providing a dummy file to supply a missing global variable fixes things.
