### PR TITLE
Fixed error in naming of dbm and gdbm modules with Python 3.x

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -567,7 +567,12 @@ add_python_extension(_curses
 )
 set(dbm2_SOURCES dbmmodule.c)
 set(dbm3_SOURCES _dbmmodule.c)
-add_python_extension(dbm
+if(IS_PY3)
+  set(dbm_name _dbm)
+else()
+  set(dbm_name dbm)
+endif()
+add_python_extension(${dbm_name}
     REQUIRES NDBM_TAG GDBM_LIBRARY GDBM_COMPAT_LIBRARY
     SOURCES ${dbm${PY_VERSION_MAJOR}_SOURCES}
     DEFINITIONS HAVE_${NDBM_TAG}_H
@@ -576,7 +581,12 @@ add_python_extension(dbm
 )
 set(gdbm2_SOURCES gdbmmodule.c)
 set(gdbm3_SOURCES _gdbmmodule.c)
-add_python_extension(gdbm
+if(IS_PY3)
+  set(gdbm_name _gdbm)
+else()
+  set(gdbm_name gdbm)
+endif()
+add_python_extension(${gdbm_name}
     REQUIRES GDBM_INCLUDE_PATH GDBM_LIBRARY GDBM_COMPAT_LIBRARY
     SOURCES ${gdbm${PY_VERSION_MAJOR}_SOURCES}
     DEFINITIONS HAVE_GDBM_DASH_NDBM_H


### PR DESCRIPTION
When compiling Python 3.5.2 I received the following error:

```
CMakeFiles/_freeze_importlib.dir/__/__/CMakeFiles/config.c.o:(.data+0x4a8): undefined reference to 'PyInit_dbm'
CMakeFiles/_freeze_importlib.dir/__/__/CMakeFiles/config.c.o:(.data+0x4b8): undefined reference to 'PyInit_gdbm'
```

Investigation of the extensions cmake file showed that dbm and gdbm were not named correctly to produce the correct PyInit function call.

I added a little logic to change the name depending on Py 2.x vs Py 3.x. All tests pass after compile.