### PR TITLE
COMP: guard '_LARGEFILE_SOURCE' to reduce warnings

### DIFF
--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1160,7 +1160,9 @@
 #cmakedefine _GNU_SOURCE 1
 
 /* This must be defined on some systems to enable large file support. */
+#ifndef _LARGEFILE_SOURCE
 #cmakedefine _LARGEFILE_SOURCE @_LARGEFILE_SOURCE@
+#endif
 
 /* This must be defined on AIX systems to enable large file support. */
 #cmakedefine _LARGE_FILES

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1160,8 +1160,12 @@
 #cmakedefine _GNU_SOURCE 1
 
 /* This must be defined on some systems to enable large file support. */
-#ifndef _LARGEFILE_SOURCE
-#cmakedefine _LARGEFILE_SOURCE @_LARGEFILE_SOURCE@
+#cmakedefine _PY_LARGEFILE_SOURCE @_LARGEFILE_SOURCE@
+#if _LARGEFILE_SOURCE != _PY_LARGEFILE_SOURCE
+# error "_LARGEFILE_SOURCE is inconsistently defined"
+#endif
+#if defined(_PY_LARGEFILE_SOURCE) && !defined(_LARGEFILE_SOURCE)
+# define _LARGEFILE_SOURCE _PY_LARGEFILE_SOURCE
 #endif
 
 /* This must be defined on AIX systems to enable large file support. */


### PR DESCRIPTION
This definition should be guarded. Some other builds/projects/etc. already define `_LARGEFILE_SOURCE`, thus inclusions of `pyconfig.h` will generate a number of warnings [1,2].

(I know this is ultimately from upstream, but we control it here and can at least reduce the warning situation for projects in CMake world)

[1]

```
In file included from Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidgetGenericTest.cxx:47:
In file included from /Users/inorton/git/slcr/s4/Base/QTGUI/qSlicerPythonManager.h:17:
In file included from /Users/inorton/git/slcr/s4/Base/QTCore/qSlicerCorePythonManager.h:25:
In file included from /Users/inorton/git/slcr/s4nj/CTK/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h:31:
In file included from /Users/inorton/git/slcr/s4nj/CTK-build/CMakeExternals/Install/include/PythonQt/PythonQtPythonInclude.h:90:
In file included from /Users/inorton/git/slcr/s4nj/python-install/include/python2.7/Python.h:8:
/Users/inorton/git/slcr/s4nj/python-install/include/python2.7/pyconfig.h:1163:9: warning: '_LARGEFILE_SOURCE' macro redefined [-Wmacro-redefined]
#define _LARGEFILE_SOURCE 1
        ^
/Users/inorton/git/slcr/s4nj/VTKv7/Common/Core/vtkWin32Header.h:36:13: note: previous definition is here
#    define _LARGEFILE_SOURCE
```

[2] tens of warnings in Slicer source build: http://slicer.cdash.org/viewBuildError.php?type=1&buildid=911731
