### PR TITLE
pyconfig: Check for _LARGEFILE_SOURCE definition inconsistency

### DIFF
--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1463,8 +1463,12 @@
 #cmakedefine _INCLUDE__STDC_A1_SOURCE 1
 
 /* This must be defined on some systems to enable large file support. */
-#ifndef _LARGEFILE_SOURCE
-#cmakedefine _LARGEFILE_SOURCE @_LARGEFILE_SOURCE@
+#cmakedefine _PY_LARGEFILE_SOURCE @_LARGEFILE_SOURCE@
+#if _LARGEFILE_SOURCE != _PY_LARGEFILE_SOURCE
+# error "_LARGEFILE_SOURCE is inconsistently defined"
+#endif
+#if defined(_PY_LARGEFILE_SOURCE) && !defined(_LARGEFILE_SOURCE)
+# define _LARGEFILE_SOURCE _PY_LARGEFILE_SOURCE
 #endif
 
 /* This must be defined on AIX systems to enable large file support. */


### PR DESCRIPTION
When embedding Python in other application, it is not practical to
follow the official recommendations [1] asking to include "Python.h" first.

Failing to do so can also causes "redefinition" warnings (see previous
commit), to mitigate this while ensuring Python code is compiled
with the expected ABI [2], this commit checks if previous definitions
of _LARGEFILE_SOURCE are consistent with the value expected by CPython
build system.

[1] https://docs.python.org/3/c-api/intro.html#include-files
[2] http://bugs.python.org/issue1045893#msg22669