### PR TITLE
Update the default Python to 3.5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(POLICY CMP0042)
 endif()
 
 if(CMAKE_CROSSCOMPILING)
-    cmake_minimum_required(VERSION 3.3) # Version introducing CROSSCOMPILING_EMULATOR
+    cmake_minimum_required(VERSION 3.6) # CROSSCOMPILING_EMULATOR support in add_custom_command
 endif()
 
 # Include helper functions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-set(PYTHON_VERSION "3.5.2" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.5.3" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)
@@ -190,6 +190,7 @@ set(_download_2.7.11_md5 "6b6076ec9e93f05dd63e47eb9c15728b")
 set(_download_2.7.12_md5 "88d61f82e3616a4be952828b3694109d")
 set(_download_3.5.1_md5 "be78e48cdfc1a7ad90efff146dce6cfe")
 set(_download_3.5.2_md5 "3fe8434643a78630c61c6464fe2e7e72")
+set(_download_3.5.3_md5 "6192f0e45f02575590760e68c621a488")
 set(_extracted_dir "Python-${PY_VERSION}")
 
 if(NOT EXISTS ${SRC_DIR}/${_landmark} AND DOWNLOAD_SOURCES)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ configuration:
 
 environment:
   matrix:
-  - PY_VERSION: 3.5.1
-    GENERATOR: Visual Studio 12 2013
-  - PY_VERSION: 3.5.1
-    GENERATOR: Visual Studio 12 2013 Win64
+  - PY_VERSION: 3.5.3
+    GENERATOR: Visual Studio 14 2015
+  - PY_VERSION: 3.5.3
+    GENERATOR: Visual Studio 14 2015 Win64
   - PY_VERSION: 2.7.12
   - PY_VERSION: 2.7.11
   - PY_VERSION: 2.7.10

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -363,6 +363,7 @@ if(UNIX)
 endif()
 if(WIN32 AND IS_PY3)
     list(APPEND LIBPYTHON_TARGET_LIBRARIES ws2_32) # Required by signalmodule
+    list(APPEND LIBPYTHON_TARGET_LIBRARIES version) # Required by sysmodule
 endif()
 
 set(LIBPYTHON_FROZEN_SOURCES )

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -237,13 +237,10 @@ set(PYTHON_COMMON_SOURCES
     ${SRC_DIR}/Python/traceback.c
     ${SRC_DIR}/Python/_warnings.c
 )
+
 if(UNIX)
     list(APPEND PYTHON_COMMON_SOURCES
         ${SRC_DIR}/Python/frozenmain.c
-    )
-else()
-    list(APPEND PYTHON_COMMON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
     )
 endif()
 
@@ -371,10 +368,17 @@ endif()
 set(LIBPYTHON_FROZEN_SOURCES )
 if(IS_PY3)
 
+# Windows needs PyImport_FrozenModules declared...
+if(WIN32)
+  set(FROZENMODULES_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/frozenmodules.c)
+endif()
+
 # Build _freeze_importlib executable
+
 add_executable(_freeze_importlib
   ${SRC_DIR}/Programs/_freeze_importlib.c
   ${LIBPYTHON_OMIT_FROZEN_SOURCES}
+  ${FROZENMODULES_SOURCE}
   )
 target_link_libraries(_freeze_importlib ${LIBPYTHON_TARGET_LIBRARIES})
 
@@ -428,17 +432,14 @@ add_executable(pgen
 set(LIBPYTHON_SOURCES
     ${LIBPYTHON_OMIT_FROZEN_SOURCES}
     ${LIBPYTHON_FROZEN_SOURCES}
+    ${SRC_DIR}/Python/frozen.c
 )
-if(UNIX)
-    list(APPEND LIBPYTHON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
-    )
-endif()
 
 # Build python libraries
 function(add_libpython name type install component)
     add_library(${name} ${type} ${LIBPYTHON_SOURCES})
     target_link_libraries(${name} ${LIBPYTHON_TARGET_LIBRARIES})
+    add_dependencies(${name} freeze_modules)
 
     if(MSVC)
         # Explicitly disable COMDAT folding. Note that this was not required

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -383,16 +383,16 @@ set(LIBPYTHON_FROZEN_SOURCES
   ${SRC_DIR}/Python/importlib_external.h
   ${SRC_DIR}/Python/importlib.h
 )
+
+
 add_custom_command(
   OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
-  COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
-      ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
-      ${SRC_DIR}/Python/importlib_external.h
-  COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
-      ${SRC_DIR}/Lib/importlib/_bootstrap.py
-      ${SRC_DIR}/Python/importlib.h
+  COMMAND _freeze_importlib
+        ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
+        ${SRC_DIR}/Python/importlib_external.h
+  COMMAND _freeze_importlib
+        ${SRC_DIR}/Lib/importlib/_bootstrap.py
+        ${SRC_DIR}/Python/importlib.h
   DEPENDS
     _freeze_importlib
     ${SRC_DIR}/Lib/importlib/_bootstrap_external.py

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -506,6 +506,21 @@ if(BUILD_LIBPYTHON_SHARED)
         )
         add_custom_target(generate_libpythonstub_def DEPENDS ${pythonstub_def})
 
+        # Build 'python3stub.lib' before linking 'python3.dll'
+        set(python3stub_lib ${PROJECT_BINARY_DIR}/${LIBPYTHON_ARCHIVEDIR}/${CMAKE_CFG_INTDIR}/python3stub.lib)
+        set(machine X86)
+        if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+            set(machine X64)
+        endif()
+        add_custom_command(
+            OUTPUT ${python3stub_lib}
+            COMMAND lib /nologo /def:${pythonstub_def} /out:${python3stub_lib} /MACHINE:${machine}
+            COMMENT "Rebuilding python3stub.lib"
+            DEPENDS generate_libpythonstub_def
+            VERBATIM
+        )
+        add_custom_target(generate_libpython3stub_lib DEPENDS ${python3stub_lib})
+
         # Build 'python3.dll'
         add_library(${targetname} SHARED ${SRC_DIR}/PC/python3dll.c ${SRC_DIR}/PC/python3.def)
         set_target_properties(${targetname} PROPERTIES
@@ -514,21 +529,7 @@ if(BUILD_LIBPYTHON_SHARED)
             RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${LIBPYTHON_LIBDIR}
             INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/${LIBPYTHON_LIBDIR}
         )
-        add_dependencies(${targetname} generate_libpythonstub_def)
-
-        # Build 'python3stub.lib' before linking 'python3.dll'
-        set(python3stub_lib ${PROJECT_BINARY_DIR}/${LIBPYTHON_ARCHIVEDIR}/${CMAKE_CFG_INTDIR}/python3stub.lib)
-        set(machine X86)
-        if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-            set(machine X64)
-        endif()
-        add_custom_command(
-            TARGET ${targetname} PRE_LINK
-            COMMAND lib /nologo /def:${pythonstub_def} /out:${python3stub_lib} /MACHINE:${machine}
-            COMMENT "Rebuilding python3stub.lib"
-            VERBATIM
-        )
-
+        add_dependencies(${targetname} generate_libpython3stub_lib)
         target_link_libraries(${targetname} ${python3stub_lib})
     endif()
 

--- a/cmake/libpython/frozenmodules.c
+++ b/cmake/libpython/frozenmodules.c
@@ -1,0 +1,9 @@
+/* Dummy frozen modules initializer for building _freeze_importlib
+   under MS Windows, as using the frozen.c from the Python
+   distribution results in a circular include of importlib.h
+*/
+
+#include <Python.h>
+#include <marshal.h>
+
+const struct _frozen *PyImport_FrozenModules;


### PR DESCRIPTION
This addresses OpenSSL-related build errors on Linux.