### PR TITLE
Fix applying patches when external source is provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,12 +235,6 @@ If you already downloaded the source, you could try to re-configure this project
 endif()
 message(STATUS "SRC_DIR: ${SRC_DIR}")
 
-# Apply patches
-option(PYTHON_APPLY_PATCHES "Apply patches" ON)
-if(PYTHON_APPLY_PATCHES)
-  include(cmake/PythonApplyPatches.cmake)
-endif()
-
 # Extract version from python source (Copied from FindPythonLibs.cmake)
 file(STRINGS "${SRC_DIR}/Include/patchlevel.h" python_version_str
     REGEX "^#define[ \t]+PY_VERSION[ \t]+\"[^\"]+\"")
@@ -256,6 +250,12 @@ set(PY_VERSION "${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}.${PY_VERSION_PATCH}")
 message(STATUS "PY_VERSION: ${PY_VERSION}")
 if(NOT DEFINED _download_${PY_VERSION}_md5)
     message(FATAL_ERROR "error: unknown python version '${PY_VERSION}'. Valid version should match '2.7.[3-13]' or '3.5.[1-2]'")
+endif()
+
+# Apply patches
+option(PYTHON_APPLY_PATCHES "Apply patches" ON)
+if(PYTHON_APPLY_PATCHES)
+  include(cmake/PythonApplyPatches.cmake)
 endif()
 
 # Convenience boolean variables to easily test python version


### PR DESCRIPTION
When an external Python source directory is provided using the SRC_DIR
option, make sure to extract the Python version from that source before
applying patches.