### PR TITLE
Python 3.6.2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ compiler:
  - clang
 
 env:
+ - PY_VERSION=3.6.2
  - PY_VERSION=3.5.2
  - PY_VERSION=3.5.1
  - PY_VERSION=2.7.13

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-set(PYTHON_VERSION "3.5.2" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.6.2" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)
@@ -191,6 +191,8 @@ set(_download_2.7.12_md5 "88d61f82e3616a4be952828b3694109d")
 set(_download_2.7.13_md5 "17add4bf0ad0ec2f08e0cae6d205c700")
 set(_download_3.5.1_md5 "be78e48cdfc1a7ad90efff146dce6cfe")
 set(_download_3.5.2_md5 "3fe8434643a78630c61c6464fe2e7e72")
+set(_download_3.6.2_md5 "e1a36bfffdd1d3a780b1825daf16e56c")
+
 set(_extracted_dir "Python-${PY_VERSION}")
 
 if(NOT EXISTS ${SRC_DIR}/${_landmark} AND DOWNLOAD_SOURCES)
@@ -249,7 +251,7 @@ string(REGEX REPLACE "[0-9]\\.[0-9]+\\.([0-9]+)[+]?" "\\1"
 set(PY_VERSION "${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}.${PY_VERSION_PATCH}")
 message(STATUS "PY_VERSION: ${PY_VERSION}")
 if(NOT DEFINED _download_${PY_VERSION}_md5)
-    message(FATAL_ERROR "error: unknown python version '${PY_VERSION}'. Valid version should match '2.7.[3-13]' or '3.5.[1-2]'")
+    message(FATAL_ERROR "error: unknown python version '${PY_VERSION}'. Valid version should match '2.7.[3-13]' or '3.5.[1-2]' or '3.6.2'")
 endif()
 
 # Apply patches
@@ -578,7 +580,7 @@ endif()
 # to go in there.  bin/python uses this to auto-determine the exec_prefix
 # and properly generate the _sysconfigdata.py
 file(MAKE_DIRECTORY "${EXTENSION_BUILD_DIR}")
-install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
+install(CODE "file(MAKE_DIRECTORY \"\$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
 
 if(BUILD_TESTING)
     set(TESTOPTS -l)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ configuration:
 environment:
   matrix:
   - PY_VERSION: 3.6.2
+    GENERATOR: Visual Studio 14 2015 Win64
   - PY_VERSION: 3.5.1
     GENERATOR: Visual Studio 12 2013
   - PY_VERSION: 3.5.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ configuration:
 
 environment:
   matrix:
+  - PY_VERSION: 3.6.2
   - PY_VERSION: 3.5.1
     GENERATOR: Visual Studio 12 2013
   - PY_VERSION: 3.5.1

--- a/cmake/UpdateSysconfig.cmake
+++ b/cmake/UpdateSysconfig.cmake
@@ -40,12 +40,22 @@ file( GLOB SYSCONFIG_FILE
       ${BIN_BUILD_DIR}/${PYBUILDDIR}/_sysconfigdata*.py
 )
 
+list( LENGTH SYSCONFIG_FILE LEN_SYSCONFIG_FILE )
 
+if( NOT LEN_SYSCONFIG_FILE EQUAL 1 )
+  message( FATAL_ERROR "expecting single sysconfig in ${SYSCONFIG_FILE}, got ${LEN_SYSCONFIG_FILE}")
+endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
   ${SYSCONFIG_FILE}
   ${PYTHON_BINARY_DIR}/${EXTENSION_INSTALL_DIR}/
 )
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E touch
+  ${PYTHON_BINARY_DIR}/${EXTENSION_INSTALL_DIR}/_generated_sysconfigdata.timestamp
+)
+
+
 
 # Create new file
 file(WRITE "${_pybuilddir}" "${EXTENSION_INSTALL_DIR}")

--- a/cmake/UpdateSysconfig.cmake
+++ b/cmake/UpdateSysconfig.cmake
@@ -35,10 +35,17 @@ endif()
 file(READ ${_pybuilddir}.backup PYBUILDDIR)
 
 # Copy _sysconfigdata.py
+file( GLOB SYSCONFIG_FILE
+      LIST_DIRECTORIES false
+      ${BIN_BUILD_DIR}/${PYBUILDDIR}/_sysconfigdata*.py
+)
+
+
+
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${BIN_BUILD_DIR}/${PYBUILDDIR}/_sysconfigdata.py
-  ${PYTHON_BINARY_DIR}/${EXTENSION_INSTALL_DIR}/_sysconfigdata.py
-  )
+  ${SYSCONFIG_FILE}
+  ${PYTHON_BINARY_DIR}/${EXTENSION_INSTALL_DIR}/
+)
 
 # Create new file
 file(WRITE "${_pybuilddir}" "${EXTENSION_INSTALL_DIR}")

--- a/cmake/python/CMakeLists.txt
+++ b/cmake/python/CMakeLists.txt
@@ -50,8 +50,9 @@ endif()
 
 if(UNIX AND PY_VERSION VERSION_GREATER "2.7.4")
     # Setup landmark allowing to run the interpreter from a build tree. See 'getpath.c' for details.
+
     add_custom_command(
-        OUTPUT ${BIN_BUILD_DIR}/pybuilddir.txt ${EXTENSION_BUILD_DIR}/_sysconfigdata.py
+      OUTPUT ${BIN_BUILD_DIR}/pybuilddir.txt ${EXTENSION_BUILD_DIR}/_generated_sysconfigdata.timestamp
         COMMAND ${PYTHON_WRAPPER_COMMAND}
           ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:python> -E -S -m sysconfig --generate-posix-vars
         COMMAND ${CMAKE_COMMAND}
@@ -64,7 +65,7 @@ if(UNIX AND PY_VERSION VERSION_GREATER "2.7.4")
         DEPENDS python
         )
     add_custom_target(update_sysconfig ALL
-        DEPENDS ${BIN_BUILD_DIR}/pybuilddir.txt ${EXTENSION_BUILD_DIR}/_sysconfigdata.py
+        DEPENDS ${BIN_BUILD_DIR}/pybuilddir.txt ${EXTENSION_BUILD_DIR}/_generated_sysconfigdata.timestamp
         )
     install( DIRECTORY ${EXTENSION_BUILD_DIR}/
         DESTINATION ${PYTHONHOME}/

--- a/cmake/python/CMakeLists.txt
+++ b/cmake/python/CMakeLists.txt
@@ -66,8 +66,10 @@ if(UNIX AND PY_VERSION VERSION_GREATER "2.7.4")
     add_custom_target(update_sysconfig ALL
         DEPENDS ${BIN_BUILD_DIR}/pybuilddir.txt ${EXTENSION_BUILD_DIR}/_sysconfigdata.py
         )
-    install(FILES ${EXTENSION_BUILD_DIR}/_sysconfigdata.py
-        DESTINATION ${PYTHONHOME}/)
+    install( DIRECTORY ${EXTENSION_BUILD_DIR}/
+        DESTINATION ${PYTHONHOME}/
+        PATTERN "_sysconfigdata*.py"
+        )
 endif()
 
 if(UNIX AND NOT CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
Wanted to integrate newest Python 3.6.2

- Added md5sum for Python 3.6.2
- Fixed an install error when installing into different directory with make install DESTDIR=/...
- Python 3.6.2 does not generate a _sysconfigdata.py any more, seems to add MACHDEP as part of the filename. So dependency checking for generation of _sysconfigdata.py does not work and install fails.

