### PR TITLE
Bugfix install if DESTDIR is given as build argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,7 +578,7 @@ endif()
 # to go in there.  bin/python uses this to auto-determine the exec_prefix
 # and properly generate the _sysconfigdata.py
 file(MAKE_DIRECTORY "${EXTENSION_BUILD_DIR}")
-install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
+install(CODE "file(MAKE_DIRECTORY \"\$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
 
 if(BUILD_TESTING)
     set(TESTOPTS -l)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,7 +578,7 @@ endif()
 # to go in there.  bin/python uses this to auto-determine the exec_prefix
 # and properly generate the _sysconfigdata.py
 file(MAKE_DIRECTORY "${EXTENSION_BUILD_DIR}")
-install(CODE "file(MAKE_DIRECTORY \"\$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
+install(CODE "file(MAKE_DIRECTORY \"\$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
 
 if(BUILD_TESTING)
     set(TESTOPTS -l)


### PR DESCRIPTION
if jom, ninja or make are called with option DESTDIR=/../  the directory for lib-dynload is not created in DESTDIR directory