### PR TITLE
compatibility with DESTDIR syntax in Unix's makefiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,7 +578,7 @@ endif()
 # to go in there.  bin/python uses this to auto-determine the exec_prefix
 # and properly generate the _sysconfigdata.py
 file(MAKE_DIRECTORY "${EXTENSION_BUILD_DIR}")
-install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
+install(DIRECTORY DESTINATION ${EXTENSION_INSTALL_DIR})
 
 if(BUILD_TESTING)
     set(TESTOPTS -l)


### PR DESCRIPTION
using custom code in install cmake command breaks the installation with a custom DESTDIR since CMAKE_INSTALL_PREFIX in the code string is evaluated at configure time, using
`install(DIRECTORY DESTINATION ${EXTENSION_INSTALL_DIR})`
has the same effect but allows to relocate the installation when calling "make install" with the DESTDIR parameter