### PR TITLE
Add support for downloading 2.7.14, 3.5.3, 3.5.4, 3.6.1 and 3.6.2 archives

### DIFF
--- a/.circleci-matrix.yml
+++ b/.circleci-matrix.yml
@@ -1,6 +1,7 @@
 env:
-  - IMAGE=linux-x86 PY_VERSION=2.7.13
-  - IMAGE=linux-x86 PY_VERSION=3.5.2
+  - IMAGE=linux-x86 PY_VERSION=2.7.14
+  - IMAGE=linux-x86 PY_VERSION=3.5.4
+  - IMAGE=linux-x86 PY_VERSION=3.6.2
 command:
   - |
     if [[ $STEP == "dependencies" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,14 @@
 os:
   - linux
-  - osx
 
 language: c
 
 compiler:
  - gcc
- - clang
 
 env:
- # 3.6
- - PY_VERSION=3.6.2
- - PY_VERSION=3.6.1
- # 3.5
- - PY_VERSION=3.5.4
- - PY_VERSION=3.5.3
- - PY_VERSION=3.5.2
- - PY_VERSION=3.5.1
- # 2.7
- - PY_VERSION=2.7.14
- - PY_VERSION=2.7.13
- - PY_VERSION=2.7.12
- - PY_VERSION=2.7.11
- - PY_VERSION=2.7.10
- - PY_VERSION=2.7.9
- - PY_VERSION=2.7.8
- - PY_VERSION=2.7.7
- - PY_VERSION=2.7.6
- - PY_VERSION=2.7.5
- - PY_VERSION=2.7.4
- - PY_VERSION=2.7.3
+ global:
+  - secure: "fjp3C/ftKPLF01wClsWXI2wz4pfgSIwiF8VUUOCjMkgLSIPWQROI3yGdZRuG7KBKBng/ssRRJ/IW98v4lRzkbx3WK6wsyubzE5+a3JSyxNB47mS1ZDIspOWhjGAbtUg5sStkE2pwWl87jpIq5HZr2ugKcR5ShSaNcbv/YrUGdD0="
 
 sudo: false
 
@@ -46,9 +25,19 @@ addons:
 before_script:
  - wget -P /tmp/ https://raw.githubusercontent.com/davidsansome/python-cmake-buildsystem/dashboard/travis_dashboard.cmake
 
+install:
+ - wget https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/travis/enable-worker-remote-access.sh -O ../enable-worker-remote-access.sh
+ - chmod u+x ../enable-worker-remote-access.sh
+
 script:
  - ctest -V -S /tmp/travis_dashboard.cmake
 
 after_script:
  - cat ${TRAVIS_BUILD_DIR}-build/CMakeCache.txt
+
+after_success:
+ - ../enable-worker-remote-access.sh
+
+after_failure:
+ - ../enable-worker-remote-access.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,16 @@ compiler:
  - clang
 
 env:
+ # 3.6
+ - PY_VERSION=3.6.2
+ - PY_VERSION=3.6.1
+ # 3.5
+ - PY_VERSION=3.5.4
+ - PY_VERSION=3.5.3
  - PY_VERSION=3.5.2
  - PY_VERSION=3.5.1
+ # 2.7
+ - PY_VERSION=2.7.14
  - PY_VERSION=2.7.13
  - PY_VERSION=2.7.12
  - PY_VERSION=2.7.11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-set(PYTHON_VERSION "3.5.2" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.6.2" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)
@@ -178,6 +178,7 @@ string(REGEX REPLACE "rc[1-9]$" "" _py_version_patch_no_rc ${PY_VERSION_PATCH})
 set(_py_version_no_rc "${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}.${_py_version_patch_no_rc}")
 set(_download_link "https://www.python.org/ftp/python/${_py_version_no_rc}/Python-${PY_VERSION}.tgz")
 # Variable below represent the set of supported python version.
+# 2.7
 set(_download_2.7.3_md5 "2cf641732ac23b18d139be077bd906cd")
 set(_download_2.7.4_md5 "592603cfaf4490a980e93ecb92bde44a")
 set(_download_2.7.5_md5 "b4f01a1d0ba0b46b05c73b2ac909b1df")
@@ -189,8 +190,16 @@ set(_download_2.7.10_md5 "d7547558fd673bd9d38e2108c6b42521")
 set(_download_2.7.11_md5 "6b6076ec9e93f05dd63e47eb9c15728b")
 set(_download_2.7.12_md5 "88d61f82e3616a4be952828b3694109d")
 set(_download_2.7.13_md5 "17add4bf0ad0ec2f08e0cae6d205c700")
+set(_download_2.7.14_md5 "cee2e4b33ad3750da77b2e85f2f8b724")
+# 3.5
 set(_download_3.5.1_md5 "be78e48cdfc1a7ad90efff146dce6cfe")
 set(_download_3.5.2_md5 "3fe8434643a78630c61c6464fe2e7e72")
+set(_download_3.5.3_md5 "6192f0e45f02575590760e68c621a488")
+set(_download_3.5.4_md5 "2ed4802b7a2a7e40d2e797272bf388ec")
+# 3.6
+set(_download_3.6.1_md5 "2d0fc9f3a5940707590e07f03ecb08b9")
+set(_download_3.6.2_md5 "e1a36bfffdd1d3a780b1825daf16e56c")
+
 set(_extracted_dir "Python-${PY_VERSION}")
 
 if(NOT EXISTS ${SRC_DIR}/${_landmark} AND DOWNLOAD_SOURCES)

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ How to use this buildsystem:
 
 .. note::
 
-  By default, the build system will download the python 3.5.2 source from
+  By default, the build system will download the python 3.6.2 source from
   http://www.python.org/ftp/python/
 
 
@@ -58,7 +58,7 @@ options on the commandline with `-DOPTION=VALUE`, or use the "ccmake" gui.
 
 ::
 
-  PYTHON_VERSION=major.minor.patch (defaults to 3.5.2)
+  PYTHON_VERSION=major.minor.patch (defaults to 3.6.2)
     The version of Python to build.
 
   PYTHON_APPLY_PATCHES=ON|OFF (defaults to ON)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,15 +14,34 @@ configuration:
 
 environment:
   matrix:
-  - PY_VERSION: 3.5.1
+  # 3.6
+  - PY_VERSION: 3.6.2
     GENERATOR: Visual Studio 12 2013
-  - PY_VERSION: 3.5.1
+  - PY_VERSION: 3.6.2
     GENERATOR: Visual Studio 12 2013 Win64
-  - PY_VERSION: 2.7.13
-  - PY_VERSION: 2.7.13
-    GENERATOR: Visual Studio 12 2013 Win64
-  - PY_VERSION: 2.7.13
+  - PY_VERSION: 3.6.2
+    GENERATOR: Visual Studio 14 2015
+  - PY_VERSION: 3.6.2
     GENERATOR: Visual Studio 14 2015 Win64
+  # 3.5
+  - PY_VERSION: 3.5.4
+    GENERATOR: Visual Studio 12 2013
+  - PY_VERSION: 3.5.4
+    GENERATOR: Visual Studio 12 2013 Win64
+  - PY_VERSION: 3.5.4
+    GENERATOR: Visual Studio 14 2015
+  - PY_VERSION: 3.5.4
+    GENERATOR: Visual Studio 14 2015 Win64
+  # 2.7
+  - PY_VERSION: 2.7.14
+    GENERATOR: Visual Studio 12 2013 Win64
+  - PY_VERSION: 2.7.14
+    GENERATOR: Visual Studio 14 2015 Win64
+  - PY_VERSION: 2.7.14
+    GENERATOR: Visual Studio 12 2013 Win64
+  - PY_VERSION: 2.7.14
+    GENERATOR: Visual Studio 14 2015 Win64
+  - PY_VERSION: 2.7.13
   - PY_VERSION: 2.7.12
   - PY_VERSION: 2.7.11
   - PY_VERSION: 2.7.10

--- a/patches/3.6/0001-Prevent-incorrect-include-of-io.h-found-in-libmpdec-.patch
+++ b/patches/3.6/0001-Prevent-incorrect-include-of-io.h-found-in-libmpdec-.patch
@@ -1,0 +1,35 @@
+From 9ec49ea39b57e69722d82b41594479a896c65ae2 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Mon, 6 Nov 2017 21:44:29 -0500
+Subject: [PATCH 1/3] Prevent incorrect include of "io.h" found in libmpdec
+ directory
+
+This commit improves support for building python with built-in extensions
+on windows where the header provided by libmpdec would be included instead
+of the system one.
+---
+ Modules/_decimal/libmpdec/io.c               | 2 +-
+ Modules/_decimal/libmpdec/{io.h => mpd_io.h} | 0
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+ rename Modules/_decimal/libmpdec/{io.h => mpd_io.h} (100%)
+
+diff --git a/Modules/_decimal/libmpdec/io.c b/Modules/_decimal/libmpdec/io.c
+index 3aadfb0..1cc719a 100644
+--- a/Modules/_decimal/libmpdec/io.c
++++ b/Modules/_decimal/libmpdec/io.c
+@@ -38,7 +38,7 @@
+ #include "bits.h"
+ #include "constants.h"
+ #include "typearith.h"
+-#include "io.h"
++#include "mpd_io.h"
+ 
+ 
+ /* This file contains functions for decimal <-> string conversions, including
+diff --git a/Modules/_decimal/libmpdec/io.h b/Modules/_decimal/libmpdec/mpd_io.h
+similarity index 100%
+rename from Modules/_decimal/libmpdec/io.h
+rename to Modules/_decimal/libmpdec/mpd_io.h
+-- 
+2.5.0
+

--- a/patches/3.6/0002-Prevent-duplicated-OverlappedType-symbols-with-built.patch
+++ b/patches/3.6/0002-Prevent-duplicated-OverlappedType-symbols-with-built.patch
@@ -1,0 +1,65 @@
+From d96bfdc9f531eaefdab931f6b2830278c2dc0226 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Mon, 6 Nov 2017 10:37:50 -0500
+Subject: [PATCH 2/3] Prevent duplicated OverlappedType symbols with built-in
+ extension on windows
+
+This commit improves support for building python with built-in extensions
+on windows where the symbol from overlapped.c would clash with the one
+from _winapi.c
+---
+ Modules/_winapi.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Modules/_winapi.c b/Modules/_winapi.c
+index 1606f0d..d81215f 100644
+--- a/Modules/_winapi.c
++++ b/Modules/_winapi.c
+@@ -147,7 +147,7 @@ overlapped_dealloc(OverlappedObject *self)
+ 
+ /*[clinic input]
+ module _winapi
+-class _winapi.Overlapped "OverlappedObject *" "&OverlappedType"
++class _winapi.Overlapped "OverlappedObject *" "&WinApiOverlappedType"
+ [clinic start generated code]*/
+ /*[clinic end generated code: output=da39a3ee5e6b4b0d input=c13d3f5fd1dabb84]*/
+ 
+@@ -295,7 +295,7 @@ static PyMemberDef overlapped_members[] = {
+     {NULL}
+ };
+ 
+-PyTypeObject OverlappedType = {
++PyTypeObject WinApiOverlappedType = {
+     PyVarObject_HEAD_INIT(NULL, 0)
+     /* tp_name           */ "_winapi.Overlapped",
+     /* tp_basicsize      */ sizeof(OverlappedObject),
+@@ -341,7 +341,7 @@ new_overlapped(HANDLE handle)
+ {
+     OverlappedObject *self;
+ 
+-    self = PyObject_New(OverlappedObject, &OverlappedType);
++    self = PyObject_New(OverlappedObject, &WinApiOverlappedType);
+     if (!self)
+         return NULL;
+     self->handle = handle;
+@@ -1537,7 +1537,7 @@ PyInit__winapi(void)
+     PyObject *d;
+     PyObject *m;
+ 
+-    if (PyType_Ready(&OverlappedType) < 0)
++    if (PyType_Ready(&WinApiOverlappedType) < 0)
+         return NULL;
+ 
+     m = PyModule_Create(&winapi_module);
+@@ -1545,7 +1545,7 @@ PyInit__winapi(void)
+         return NULL;
+     d = PyModule_GetDict(m);
+ 
+-    PyDict_SetItemString(d, "Overlapped", (PyObject *) &OverlappedType);
++    PyDict_SetItemString(d, "Overlapped", (PyObject *) &WinApiOverlappedType);
+ 
+     /* constants */
+     WINAPI_CONSTANT(F_DWORD, CREATE_NEW_CONSOLE);
+-- 
+2.5.0
+

--- a/patches/3.6/0003-mpdecimal-Export-inlined-functions-to-support-extens.patch
+++ b/patches/3.6/0003-mpdecimal-Export-inlined-functions-to-support-extens.patch
@@ -1,0 +1,36 @@
+From 12cd7e4b43f85822d8ab0531cb3097e5f32bd5ff Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Mon, 6 Nov 2017 11:27:32 -0500
+Subject: [PATCH 3/3] mpdecimal: Export inlined functions to support extension
+ built-in on windows
+
+This commit ensures that symbols are available when building _freeze_importlib
+with all extensions built-in on windows.
+
+It addresses the following link error associated
+with CMakeBuild\libpython\_freeze_importlib.vcxproj:
+
+  3>_decimal.obj : error LNK2019: unresolved external symbol _mpd_del referenced in function _PyDec_AsTuple
+  3>io.obj : error LNK2001: unresolved external symbol _mpd_del
+  3>basearith.obj : error LNK2019: unresolved external symbol _mpd_uint_zero referenced in function __mpd_baseshiftl
+  3>io.obj : error LNK2019: unresolved external symbol _mpd_qresize referenced in function _mpd_qset_string
+---
+ Modules/_decimal/libmpdec/mpdecimal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/_decimal/libmpdec/mpdecimal.c b/Modules/_decimal/libmpdec/mpdecimal.c
+index 328ab92..5812bcd 100644
+--- a/Modules/_decimal/libmpdec/mpdecimal.c
++++ b/Modules/_decimal/libmpdec/mpdecimal.c
+@@ -54,7 +54,7 @@
+ 
+ 
+ #if defined(_MSC_VER)
+-  #define ALWAYS_INLINE __forceinline
++  #define ALWAYS_INLINE extern __forceinline
+ #elif defined(LEGACY_COMPILER)
+   #define ALWAYS_INLINE
+   #undef inline
+-- 
+2.5.0
+

--- a/patches/3.6/README.rst
+++ b/patches/3.6/README.rst
@@ -1,0 +1,10 @@
+* ``0001-Prevent-incorrect-include-of-io.h-found-in-libmpdec-.patch``: Rename header files found in
+  ``Modules/_decimal/libmpdec`` directory to avoid conflicts with system headers of the same name.
+
+* ``0002-Prevent-duplicated-OverlappedType-symbols-with-built.patch``: Prevent duplicated OverlappedType
+  symbols with built-in extension on Windows.
+
+* ``0003-mpdecimal-Export-inlined-functions-to-support-extens.patch``: Export inlined functions to
+  support extension built-in on Windows.
+
+


### PR DESCRIPTION
* Update default version from 3.5.2 to 3.6.2

* Add patches to support building python 3.6.x with BUILD_EXTENSIONS_AS_BUILTIN
  set to ON on Windows.