### PR TITLE
Don't set_target_properties on an extension when it's disabled.

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -449,7 +449,7 @@ add_python_extension(_decimal
     ${_decimal_LIBRARIES}
     ${_decimal_INCLUDEDIRS}
 )
-if(_decimal_compile_flags AND NOT BUILTIN_DECIMAL)
+if(_decimal_compile_flags AND ENABLE_DECIMAL AND NOT BUILTIN_DECIMAL)
     set_target_properties(extension_decimal PROPERTIES COMPILE_FLAGS ${_decimal_compile_flags})
 endif()
 
@@ -682,7 +682,7 @@ else()
     )
 endif()
 
-if(USE_LIBEDIT AND NOT BUILTIN_READLINE)
+if(USE_LIBEDIT AND ENABLE_READLINE AND NOT BUILTIN_READLINE)
     set_target_properties(extension_readline PROPERTIES
         COMPILE_DEFINITIONS "USE_LIBEDIT")
 endif()


### PR DESCRIPTION
When ENABLE_{extension} is explicitly set to OFF, don't need to call the set_target_properties on that extension.