### PR TITLE
Fix install on system without python already on the system

### DIFF
--- a/cmake/lib/CMakeLists.txt
+++ b/cmake/lib/CMakeLists.txt
@@ -47,8 +47,16 @@ install(CODE "find_program(
   PYTHON_EXECUTABLE python
   HINTS \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}
   NO_DEFAULT_PATH)
-execute_process(COMMAND \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
+set(wrapper)
+if(UNIX)
+  set(_envvar LD_LIBRARY_PATH)
+  if(APPLE)
+    set(_envvar DYLD_LIBRARY_PATH)
+  endif()
+  set(wrapper env \${_envvar}=\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBPYTHON_LIBDIR})
+endif()
+execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
   \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/Grammar.txt)
-execute_process(COMMAND \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
+execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
   \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/PatternGrammar.txt)
 ")


### PR DESCRIPTION
This commit ensures the Grammar generation (current happening at install
time) can complete no system without python already installed on the system.

It fixes error like the following:

-- Up-to-date: /work/Preview/Slicer-0-build/python-install/include/python2.7/pyconfig.h
/path/to/python-install/bin/python: error while loading shared libraries: libpython2.7.so: cannot open shared object file: No such file or directory
/path/to/python-install/bin/python: error while loading shared libraries: libpython2.7.so: cannot open shared object file: No such file or directory