### PR TITLE
Fixes: Git executable from find package not used.

### DIFF
--- a/cmake/PythonApplyPatches.cmake
+++ b/cmake/PythonApplyPatches.cmake
@@ -12,7 +12,7 @@ if(NOT DEFINED PATCH_COMMAND)
     # is located within an already versioned tree.
     if(NOT EXISTS "${SRC_DIR}/.git")
       execute_process(
-        COMMAND git init
+        COMMAND ${GIT_EXECUTABLE} init
         WORKING_DIRECTORY ${SRC_DIR}
         RESULT_VARIABLE result
         ERROR_VARIABLE error


### PR DESCRIPTION
Git executable found from find_package wasn't used.
With this change it's found and used, even if git is not present in the path variable.