### PR TITLE
Fix sqlite3 import by matching upstream build option for load_extension

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -640,7 +640,7 @@ add_python_extension(_sqlite3
             _sqlite/row.c
             _sqlite/statement.c
             _sqlite/util.c
-    DEFINITIONS MODULE_NAME="sqlite3"
+    DEFINITIONS MODULE_NAME="sqlite3" SQLITE_OMIT_LOAD_EXTENSION=1
     INCLUDEDIRS ${SQLITE3_INCLUDE_PATH}
     LIBRARIES ${SQLITE3_LIBRARY}
 )


### PR DESCRIPTION
Per upstream [documentation](https://docs.python.org/2/library/sqlite3.html#f1):

> The sqlite3 module is not built with loadable extension support by
> default, because some platforms (notably Mac OS X) have SQLite
> libraries which are compiled without this feature. To get loadable
> extension support, you must modify setup.py and remove the line that
> sets SQLITE_OMIT_LOAD_EXTENSION.

which means that SQLITE_OMIT_LOAD_EXTENSION is added as a compile
definition by default in the upstream build system. We match that
here to fix `import sqlite3`.