### PR TITLE
re: Build debug libraries when CMAKE_BUILD_TYPE is set to Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CMAKE_CROSSCOMPILING)
     cmake_minimum_required(VERSION 3.3) # Version introducing CROSSCOMPILING_EMULATOR
 endif()
 
-if(WIN32 AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     set(CMAKE_DEBUG_POSTFIX "_d")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ if(CMAKE_CROSSCOMPILING)
     cmake_minimum_required(VERSION 3.3) # Version introducing CROSSCOMPILING_EMULATOR
 endif()
 
+if(WIN32 AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    set(CMAKE_DEBUG_POSTFIX "_d")
+endif()
+
 # Include helper functions
 include(cmake/CMakeChecks.cmake)
 include(cmake/Extensions.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CMAKE_CROSSCOMPILING)
     cmake_minimum_required(VERSION 3.3) # Version introducing CROSSCOMPILING_EMULATOR
 endif()
 
-if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+if(MSVC)
     set(CMAKE_DEBUG_POSTFIX "_d")
 endif()
 

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -122,10 +122,13 @@ add_python_extension(_testmultiphase REQUIRES IS_PY3 SOURCES _testmultiphase.c)
 # debug tool to trace memory blocks allocated by Python
 add_python_extension(_tracemalloc BUILTIN REQUIRES IS_PY3 SOURCES hashtable.c _tracemalloc.c)
 add_python_extension(_weakref BUILTIN REQUIRES IS_PY3 SOURCES _weakref.c)
-math(EXPR _limited_api_version "${PY_VERSION_MAJOR} * 100 + ${PY_VERSION_MINOR}")
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    math(EXPR _limited_api_version "${PY_VERSION_MAJOR} * 100 + ${PY_VERSION_MINOR}")
+    set(_limited_definition "Py_LIMITED_API=0x${_limited_api_version}0000")
+endif()
 add_python_extension(xxlimited REQUIRES IS_PY3 BUILD_TESTING
     SOURCES xxlimited.c
-    DEFINITIONS Py_LIMITED_API=0x${_limited_api_version}0000
+    DEFINITIONS ${_limited_definition}
     NO_INSTALL
 )
 add_python_extension(xxsubtype BUILTIN REQUIRES IS_PY3 SOURCES xxsubtype.c)


### PR DESCRIPTION
Supersede PR #151 