### PR TITLE
Prevent a circular import when rebuilding Python under MS Windows.

### DIFF
--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -250,13 +250,10 @@ set(PYTHON_COMMON_SOURCES
     ${SRC_DIR}/Python/traceback.c
     ${SRC_DIR}/Python/_warnings.c
 )
+
 if(UNIX)
     list(APPEND PYTHON_COMMON_SOURCES
         ${SRC_DIR}/Python/frozenmain.c
-    )
-else()
-    list(APPEND PYTHON_COMMON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
     )
 endif()
 
@@ -394,10 +391,16 @@ endif()
 set(LIBPYTHON_FROZEN_SOURCES )
 if(IS_PY3)
 
+# Windows needs PyImport_FrozenModules declared...
+if(WIN32)
+  set(FROZENMODULES_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/frozenmodules.c)
+endif()
+
 # Build _freeze_importlib executable
 add_executable(_freeze_importlib
   ${SRC_DIR}/Programs/_freeze_importlib.c
   ${LIBPYTHON_OMIT_FROZEN_SOURCES}
+  ${FROZENMODULES_SOURCE}
   )
 target_link_libraries(_freeze_importlib ${LIBPYTHON_TARGET_LIBRARIES})
 if(builtin_compile_definitions_without_py_limited_api)
@@ -457,12 +460,8 @@ endif()
 set(LIBPYTHON_SOURCES
     ${LIBPYTHON_OMIT_FROZEN_SOURCES}
     ${LIBPYTHON_FROZEN_SOURCES}
+    ${SRC_DIR}/Python/frozen.c
 )
-if(UNIX)
-    list(APPEND LIBPYTHON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
-    )
-endif()
 
 # Build python libraries
 function(add_libpython name type install component)

--- a/cmake/libpython/frozenmodules.c
+++ b/cmake/libpython/frozenmodules.c
@@ -1,0 +1,8 @@
+/* Dummy frozen modules initializer for building _freeze_importlib
+   under MS Windows, as using the frozen.c from the Python
+   distribution results in a circular include of importlib.h
+*/
+#include <Python.h>
+#include <marshal.h>
+
+const struct _frozen *PyImport_FrozenModules;


### PR DESCRIPTION
A rebased PR #152. Tested under Windows with Ninja.