### PR TITLE
patch - fix iomodule.c for VS 2017

### DIFF
--- a/patches/3.6/0004-Fix-Windows-build-of-Python-for-latest-WinSDK.patch
+++ b/patches/3.6/0004-Fix-Windows-build-of-Python-for-latest-WinSDK.patch
@@ -1,0 +1,26 @@
+From ca436844d5dddcb0156ada7fadc9fa4c38d8bcbe Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Fri, 12 Apr 2019 16:36:42 -0400
+Subject: [PATCH 4/4] Fix Windows build of Python for latest WinSDK.
+
+This is a partial backport of https://github.com/python/cpython/commit/df4852cbe4b757e8b79506d73a09ec8a1b595970
+---
+ Modules/_io/_iomodule.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/_io/_iomodule.c b/Modules/_io/_iomodule.c
+index f4d3cbd49f..f7ad176990 100644
+--- a/Modules/_io/_iomodule.c
++++ b/Modules/_io/_iomodule.c
+@@ -21,7 +21,7 @@
+ #endif /* HAVE_SYS_STAT_H */
+ 
+ #ifdef MS_WINDOWS
+-#include <consoleapi.h>
++#include <windows.h>
+ #endif
+ 
+ /* Various interned strings */
+-- 
+2.11.0
+

--- a/patches/3.6/README.rst
+++ b/patches/3.6/README.rst
@@ -7,4 +7,6 @@
 * ``0003-mpdecimal-Export-inlined-functions-to-support-extens.patch``: Export inlined functions to
   support extension built-in on Windows.
 
-
+* ``0004-Fix-Windows-build-of-Python-for-latest-WinSDK.patch``: Fix build of iomodule using
+  Visual Studio >= 2017. It is a partial backport of commit [python/cpython@df4852c](https://github.com/python/cpython/commit/df4852cbe4b757e8b79506d73a09ec8a1b595970)
+  originally associated with [CPython GH-6874](https://github.com/python/cpython/pull/6874).


### PR DESCRIPTION
VS 2017 has a new Windows SDK
iomodule.c needs windows.h to compile
this supplies a patch to add window.h to the module

related

[Fix CMake Build for MSVC 15 2017 #233](https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/issues/233)