### PR TITLE
cmake: Disable weak linking to "fix Symbol not found: _clock_gettime"

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -1326,7 +1326,33 @@ endif()
 
 if(IS_PY3)
 
-check_function_exists(clock_getres HAVE_CLOCK_GETRES)
+if(APPLE)
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_FLAGS "-Wl,-no_weak_imports")
+  CHECK_C_SOURCE_COMPILES("int main(void) { return 0; }" SUPPORT_NO_WEAK_IMPORT_FLAG)
+  cmake_pop_check_state()
+else()
+  set(SUPPORT_NO_WEAK_IMPORT_FLAG 0)
+endif()
+
+cmake_push_check_state()
+set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/clock_getres.c)
+file(WRITE ${check_src} "
+#include <stdio.h>
+#include <time.h>
+int main() { return clock_getres(0, NULL); }
+")
+if(SUPPORT_NO_WEAK_IMPORT_FLAG)
+  set(CMAKE_REQUIRED_FLAGS "-Wl,-no_weak_imports")
+endif()
+python_platform_test(
+  HAVE_CLOCK_GETRES
+  "Checking for clock_getres"
+  ${check_src}
+  DIRECT
+  )
+cmake_pop_check_state()
+
 if(NOT HAVE_CLOCK_GETRES)
   cmake_push_check_state()
   set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_lib_rt_clock_getres.c)
@@ -1349,7 +1375,23 @@ if(NOT HAVE_CLOCK_GETRES)
   cmake_pop_check_state()
 endif()
 
-check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
+cmake_push_check_state()
+set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/clock_gettime.c)
+file(WRITE ${check_src} "
+#include <stdio.h>
+#include <time.h>
+int main() { return clock_gettime(0, NULL); }
+")
+if(SUPPORT_NO_WEAK_IMPORT_FLAG)
+  set(CMAKE_REQUIRED_FLAGS "-Wl,-no_weak_imports")
+endif()
+python_platform_test(
+  HAVE_CLOCK_GETTIME
+  "Checking for clock_gettime"
+  ${check_src}
+  DIRECT
+  )
+cmake_pop_check_state()
 if(NOT HAVE_CLOCK_GETTIME)
   cmake_push_check_state()
   set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_lib_rt_clock_gettime.c)


### PR DESCRIPTION
This commit was adapted from the work done by @sitsofe in
https://github.com/axboe/fio/pull/309/commits/ccf2d89d39b21bc8c7b497b40be5b82eadb80863

Description below was copied verbatim from the commit referenced above.

macOS 10.12 introduced support for clock_gettime() but when compiling
with Xcode 8 (or later) and targeting 10.11 (or older) the clock_gettime
symbol is now found at configure/compile time but referenced weakly.
Running the created binary on 10.11 results in a "dyld: lazy symbol
binding failed: Symbol not found: _clock_gettime" error.

Options for working around this issue include:

1. Turn references to functions that might be weak into compilation
   errors (-Werror=partial-availability).

2. Disable visibility of functions that might be weak at compile link
   time (-Wl,-no_weak_imports).

3. Change configure tests to directly check the targeted OSX version and
   fail the test if it is too old to have the required function.

4. Make an empty function declaration marked with
   __attribute__((weak_import)) that is used if the symbol would
   otherwise be unavailable. It is then possible to check if the symbol
   is NULL at runtime to determine availability.

This commit implements approach (2) when targeting the Darwin platform
after checking that the compiler/linker work with that option.

Co-authored-by: Sitsofe Wheeler <sitsofe@yahoo.com>