### PR TITLE
Upgrade to Python 3.7.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-set(PYTHON_VERSION "3.6.7" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.6.8" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)
@@ -206,6 +206,7 @@ set(_download_3.6.4_md5 "9de6494314ea199e3633211696735f65")
 set(_download_3.6.5_md5 "ab25d24b1f8cc4990ade979f6dc37883")
 set(_download_3.6.6_md5 "9a080a86e1a8d85e45eee4b1cd0a18a2")
 set(_download_3.6.7_md5 "c83551d83bf015134b4b2249213f3f85")
+set(_download_3.6.8_md5 "48f393a04c2e66c77bfc114e589ec630")
 
 set(_extracted_dir "Python-${PY_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-set(PYTHON_VERSION "3.6.8" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.7.4" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)
@@ -207,6 +207,10 @@ set(_download_3.6.5_md5 "ab25d24b1f8cc4990ade979f6dc37883")
 set(_download_3.6.6_md5 "9a080a86e1a8d85e45eee4b1cd0a18a2")
 set(_download_3.6.7_md5 "c83551d83bf015134b4b2249213f3f85")
 set(_download_3.6.8_md5 "48f393a04c2e66c77bfc114e589ec630")
+set(_download_3.7.0_md5 "41b6595deb4147a1ed517a7d9a580271")
+set(_download_3.7.1_md5 "99f78ecbfc766ea449c4d9e7eda19e83")
+set(_download_3.7.2_md5 "02a75015f7cd845e27b85192bb0ca4cb")
+set(_download_3.7.4_md5 "68111671e5b2db4aef7b9ab01bf0f9be")
 
 set(_extracted_dir "Python-${PY_VERSION}")
 

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -106,6 +106,8 @@ endif()
 
 find_path(SQLITE3_INCLUDE_PATH sqlite3.h)
 find_library(SQLITE3_LIBRARY sqlite3)
+find_library(UUID_LIBRARY uuid)
+message( STATUS "UUID_LIBRARY=${UUID_LIBRARY}")
 
 if(WIN32)
   set(M_LIBRARIES )
@@ -307,6 +309,8 @@ check_include_files(sys/syscall.h HAVE_SYS_SYSCALL_H)
 check_include_files(sys/sys_domain.h HAVE_SYS_SYS_DOMAIN_H)
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)
 check_include_files(sys/xattr.h HAVE_SYS_XATTR_H)
+check_include_files(uuid/uuid.h HAVE_UUID_UUID_H)
+check_include_files(uuid.h HAVE_UUID_H)
 
 # On Darwin (OS X) net/if.h requires sys/socket.h to be imported first.
 set(NET_IF_HEADERS stdio.h)
@@ -702,6 +706,8 @@ add_cond(CFG_HEADERS HAVE_SYS_ENDIAN_H sys/endian.h)
 add_cond(CFG_HEADERS HAVE_SYS_RESOURCE_H sys/resource.h)
 add_cond(CFG_HEADERS HAVE_SYS_SENDFILE_H sys/sendfile.h)
 add_cond(CFG_HEADERS HAVE_SYS_TIME_H sys/time.h)
+add_cond(CFG_HEADERS HAVE_UUID_UUID_H uuid/uuid.h)
+add_cond(CFG_HEADERS HAVE_UUID_H uuid.h)
 endif()
 
 if(HAVE_PTY_H)

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1067,6 +1067,12 @@
 /* Define to 1 if you have the <sys/time.h> header file. */
 #cmakedefine HAVE_SYS_TIME_H 1
 
+/* Define to 1 if you have the <uuid/uuid.h> header file. */
+#cmakedefine HAVE_UUID_H 0
+
+/* Define to 1 if you have the <uuid/uuid.h> header file. */
+#cmakedefine HAVE_UUID_UUID_H 1
+
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine HAVE_SYS_TYPES_H 1
 

--- a/cmake/config_3.c.in
+++ b/cmake/config_3.c.in
@@ -35,7 +35,7 @@ struct _inittab _PyImport_Inittab[] = {
     {"marshal", PyMarshal_Init},
 
     /* This lives in import.c */
-    {"_imp", PyInit_imp},
+    {"_imp", PyInit__imp}, /* 3.7 was single _ */
 
     /* This lives in Python/Python-ast.c */
     {"_ast", PyInit__ast},

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -61,7 +61,7 @@ add_python_extension(${datetime${PY_VERSION_MAJOR}_NAME} ${WIN32_BUILTIN} REQUIR
 #if(ENABLE_DATETIME AND CMAKE_C_COMPILER_ID MATCHES GNU)
 #    set_property(SOURCE ${SRC_DIR}/Modules/datetimemodule.c PROPERTY COMPILE_FLAGS -Wno-unused-value)
 #endif()
-add_python_extension(_functools ${WIN32_BUILTIN} SOURCES _functoolsmodule.c) # Tools for working with functions and callable objects
+add_python_extension(_functools ${WIN32_BUILTIN} DEFINITIONS Py_BUILD_CORE SOURCES _functoolsmodule.c) # Tools for working with functions and callable objects
 add_python_extension(future_builtins ${WIN32_BUILTIN} REQUIRES IS_PY2 SOURCES future_builtins.c)
 add_python_extension(_heapq ${WIN32_BUILTIN} SOURCES _heapqmodule.c)
 add_python_extension(_hotshot ${WIN32_BUILTIN} REQUIRES IS_PY2 SOURCES _hotshot.c)
@@ -92,6 +92,7 @@ add_python_extension(_multibytecodec ${WIN32_BUILTIN} SOURCES cjkcodecs/multibyt
 add_python_extension(operator ${WIN32_BUILTIN} REQUIRES IS_PY2 SOURCES operator.c)
 add_python_extension(parser ${WIN32_BUILTIN} SOURCES parsermodule.c)
 add_python_extension(_random ${WIN32_BUILTIN} SOURCES _randommodule.c)
+add_python_extension(_queue ${WIN32_BUILTIN} IS_PY3 SOURCES _queuemodule.c)
 add_python_extension(strop ${WIN32_BUILTIN} REQUIRES IS_PY2 SOURCES stropmodule.c)
 add_python_extension(_struct ${WIN32_BUILTIN} SOURCES _struct.c)
 add_python_extension(_testcapi SOURCES _testcapimodule.c)
@@ -104,8 +105,10 @@ add_python_extension(time BUILTIN REQUIRES HAVE_LIBM SOURCES timemodule.c LIBRAR
 add_python_extension(unicodedata SOURCES unicodedata.c)
 
 # Python3
+add_python_extension(_abc BUILTIN IS_PY3 SOURCES _abc.c)
 add_python_extension(atexit BUILTIN REQUIRES IS_PY3 SOURCES atexitmodule.c) # Register functions to be run at interpreter-shutdown
 add_python_extension(_codecs BUILTIN REQUIRES IS_PY3 SOURCES _codecsmodule.c) # access to the builtin codecs and codec registry
+add_python_extension(_contextvars BUILTIN IS_PY3 SOURCES SOURCES _contextvarsmodule.c)
 add_python_extension(faulthandler BUILTIN REQUIRES IS_PY3 SOURCES faulthandler.c)
 add_python_extension(_opcode BUILTIN REQUIRES IS_PY3 SOURCES _opcode.c)
 add_python_extension(_operator ${WIN32_BUILTIN} REQUIRES IS_PY3 SOURCES _operator.c)

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -263,14 +263,6 @@ else()
     )
 endif()
 
-set(_libffi_system_dir ${CMAKE_SYSTEM_PROCESSOR})
-if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
-  set(_libffi_system_dir "x86")
-elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
-  set(_libffi_system_dir "x86")
-elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
-  set(_libffi_system_dir "arm")
-endif()
 # Common ctypes sources
 set(ctypes_COMMON_SOURCES
     _ctypes/_ctypes.c
@@ -312,7 +304,6 @@ if(WIN32)
         )
     endif()
 else()
-    set(_libffi_system_extra_src)
     if(APPLE)
         add_python_extension(_ctypes
             SOURCES ${ctypes_COMMON_SOURCES}
@@ -328,37 +319,13 @@ else()
             DEFINITIONS MACOSX
         )
     else()
-        if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
-          set(_libffi_system_extra_src
-                _ctypes/libffi/src/${_libffi_system_dir}/ffi64.c
-                _ctypes/libffi/src/${_libffi_system_dir}/unix64.S
-                )
-        elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
-          set(_libffi_system_extra_src
-                _ctypes/libffi/src/${_libffi_system_dir}/win32.S
-                )
-        endif()
-        # To facilitate an eventual contribution of the configuration
-        # of fficonfig.h to the upstream project, corresponding tests
-        # in ConfigureChecks.cmake are labeled using this convention:
-        # * "libffi specific"
-        # * "libffi and cpython"
-        set(LIBFFI_VERSION "3.1")
-        configure_file(
-          ${PROJECT_SOURCE_DIR}/cmake/fficonfig.h.in
-          ${INCLUDE_BUILD_DIR}/fficonfig.h
-          )
+        # get libffi
+        find_path(FFI_INCLUDE_DIR ffi.h)
+        find_library(FFI_LIBRARY NAMES ffi libffi)
         add_python_extension(_ctypes
             SOURCES ${ctypes_COMMON_SOURCES}
-                    _ctypes/libffi/src/closures.c
-                    _ctypes/libffi/src/prep_cif.c
-                    _ctypes/libffi/src/${_libffi_system_dir}/ffi.c
-                    _ctypes/libffi/src/${_libffi_system_dir}/sysv.S
-                    ${_libffi_system_extra_src}
-            INCLUDEDIRS ${SRC_DIR}/Modules/_ctypes/libffi/src/${_libffi_system_dir}
-                        ${SRC_DIR}/Modules/_ctypes/libffi/include
-                        ${INCLUDE_BUILD_DIR}      # For fficonfig.h
-                        ${PROJECT_SOURCE_DIR}/cmake # For ffi.h
+            INCLUDEDIRS ${FFI_INCLUDE_DIR}
+            LIBRARIES ${FFI_LIBRARY}
         )
     endif()
 endif()

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -159,6 +159,7 @@ add_python_extension(syslog REQUIRES UNIX SOURCES syslogmodule.c)
 add_python_extension(termios REQUIRES UNIX SOURCES termios.c)
 
 # Python3: UNIX-only extensions
+add_python_extension(_uuid BUILTIN REQUIRES IS_PY3 UNIX SOURCES _uuidmodule.c LIBRARIES ${UUID_LIBRARY})
 add_python_extension(errno BUILTIN REQUIRES IS_PY3 UNIX SOURCES errnomodule.c)
 add_python_extension(_posixsubprocess BUILTIN REQUIRES IS_PY3 UNIX SOURCES _posixsubprocess.c)
 

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_definitions(-DPy_BUILD_CORE)
 add_definitions(-DNDEBUG)
+add_definitions(-D_PYTHONFRAMEWORK="")
+
 
 set(MODULE_SOURCES # Equivalent to MODULE_OBJS in Makefile.pre
     ${PROJECT_BINARY_DIR}/CMakeFiles/config.c

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -110,6 +110,7 @@ set(OBJECT_COMMON_SOURCES # Equivalent to OBJECT_OBJS in Makefile.pre
     ${SRC_DIR}/Objects/boolobject.c
     ${SRC_DIR}/Objects/bytearrayobject.c
     ${SRC_DIR}/Objects/bytes_methods.c
+    ${SRC_DIR}/Objects/call.c
     ${SRC_DIR}/Objects/capsule.c
     ${SRC_DIR}/Objects/cellobject.c
     ${SRC_DIR}/Objects/classobject.c
@@ -205,6 +206,7 @@ set(PYTHON3_COMMON_SOURCES
     ${SRC_DIR}/Python/pystrhex.c
     ${SRC_DIR}/Python/pystrtod.c
     ${SRC_DIR}/Python/pytime.c
+    ${SRC_DIR}/Python/bootstrap_hash.c
 )
 
 set(PYTHON_COMMON_SOURCES
@@ -213,6 +215,8 @@ set(PYTHON_COMMON_SOURCES
     ${THREAD_SOURCES}
     ${SRC_DIR}/Python/asdl.c
     ${SRC_DIR}/Python/ast.c
+    ${SRC_DIR}/Python/ast_opt.c
+    ${SRC_DIR}/Python/ast_unparse.c
     ${SRC_DIR}/Python/bltinmodule.c
     ${SRC_DIR}/Python/ceval.c
     ${SRC_DIR}/Python/codecs.c
@@ -234,16 +238,18 @@ set(PYTHON_COMMON_SOURCES
     ${SRC_DIR}/Python/modsupport.c
     ${SRC_DIR}/Python/mysnprintf.c
     ${SRC_DIR}/Python/mystrtoul.c
+    ${SRC_DIR}/Python/pathconfig.c
     ${SRC_DIR}/Python/peephole.c
     ${SRC_DIR}/Python/pyarena.c
     ${SRC_DIR}/Python/pyctype.c
     ${SRC_DIR}/Python/pyfpe.c
     ${SRC_DIR}/Python/pymath.c
     ${SRC_DIR}/Python/pystate.c
+    ${SRC_DIR}/Python/context.c
     ${SRC_DIR}/Python/pystrcmp.c
     ${SRC_DIR}/Python/Python-ast.c
+    ${SRC_DIR}/Python/hamt.c
     ${SRC_DIR}/Python/pythonrun.c
-    ${SRC_DIR}/Python/random.c
     ${SRC_DIR}/Python/structmember.c
     ${SRC_DIR}/Python/symtable.c
     ${SRC_DIR}/Python/sysmodule.c

--- a/patches/3.7/0001-Prevent-incorrect-include-of-io.h-found-in-libmpdec-.patch
+++ b/patches/3.7/0001-Prevent-incorrect-include-of-io.h-found-in-libmpdec-.patch
@@ -1,0 +1,35 @@
+From 9ec49ea39b57e69722d82b41594479a896c65ae2 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Mon, 6 Nov 2017 21:44:29 -0500
+Subject: [PATCH 1/3] Prevent incorrect include of "io.h" found in libmpdec
+ directory
+
+This commit improves support for building python with built-in extensions
+on windows where the header provided by libmpdec would be included instead
+of the system one.
+---
+ Modules/_decimal/libmpdec/io.c               | 2 +-
+ Modules/_decimal/libmpdec/{io.h => mpd_io.h} | 0
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+ rename Modules/_decimal/libmpdec/{io.h => mpd_io.h} (100%)
+
+diff --git a/Modules/_decimal/libmpdec/io.c b/Modules/_decimal/libmpdec/io.c
+index 3aadfb0..1cc719a 100644
+--- a/Modules/_decimal/libmpdec/io.c
++++ b/Modules/_decimal/libmpdec/io.c
+@@ -38,7 +38,7 @@
+ #include "bits.h"
+ #include "constants.h"
+ #include "typearith.h"
+-#include "io.h"
++#include "mpd_io.h"
+ 
+ 
+ /* This file contains functions for decimal <-> string conversions, including
+diff --git a/Modules/_decimal/libmpdec/io.h b/Modules/_decimal/libmpdec/mpd_io.h
+similarity index 100%
+rename from Modules/_decimal/libmpdec/io.h
+rename to Modules/_decimal/libmpdec/mpd_io.h
+-- 
+2.5.0
+

--- a/patches/3.7/0002-Prevent-duplicated-OverlappedType-symbols-with-built.patch
+++ b/patches/3.7/0002-Prevent-duplicated-OverlappedType-symbols-with-built.patch
@@ -1,0 +1,65 @@
+From d96bfdc9f531eaefdab931f6b2830278c2dc0226 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Mon, 6 Nov 2017 10:37:50 -0500
+Subject: [PATCH 2/3] Prevent duplicated OverlappedType symbols with built-in
+ extension on windows
+
+This commit improves support for building python with built-in extensions
+on windows where the symbol from overlapped.c would clash with the one
+from _winapi.c
+---
+ Modules/_winapi.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Modules/_winapi.c b/Modules/_winapi.c
+index 1606f0d..d81215f 100644
+--- a/Modules/_winapi.c
++++ b/Modules/_winapi.c
+@@ -147,7 +147,7 @@ overlapped_dealloc(OverlappedObject *self)
+ 
+ /*[clinic input]
+ module _winapi
+-class _winapi.Overlapped "OverlappedObject *" "&OverlappedType"
++class _winapi.Overlapped "OverlappedObject *" "&WinApiOverlappedType"
+ [clinic start generated code]*/
+ /*[clinic end generated code: output=da39a3ee5e6b4b0d input=c13d3f5fd1dabb84]*/
+ 
+@@ -295,7 +295,7 @@ static PyMemberDef overlapped_members[] = {
+     {NULL}
+ };
+ 
+-PyTypeObject OverlappedType = {
++PyTypeObject WinApiOverlappedType = {
+     PyVarObject_HEAD_INIT(NULL, 0)
+     /* tp_name           */ "_winapi.Overlapped",
+     /* tp_basicsize      */ sizeof(OverlappedObject),
+@@ -341,7 +341,7 @@ new_overlapped(HANDLE handle)
+ {
+     OverlappedObject *self;
+ 
+-    self = PyObject_New(OverlappedObject, &OverlappedType);
++    self = PyObject_New(OverlappedObject, &WinApiOverlappedType);
+     if (!self)
+         return NULL;
+     self->handle = handle;
+@@ -1537,7 +1537,7 @@ PyInit__winapi(void)
+     PyObject *d;
+     PyObject *m;
+ 
+-    if (PyType_Ready(&OverlappedType) < 0)
++    if (PyType_Ready(&WinApiOverlappedType) < 0)
+         return NULL;
+ 
+     m = PyModule_Create(&winapi_module);
+@@ -1545,7 +1545,7 @@ PyInit__winapi(void)
+         return NULL;
+     d = PyModule_GetDict(m);
+ 
+-    PyDict_SetItemString(d, "Overlapped", (PyObject *) &OverlappedType);
++    PyDict_SetItemString(d, "Overlapped", (PyObject *) &WinApiOverlappedType);
+ 
+     /* constants */
+     WINAPI_CONSTANT(F_DWORD, CREATE_NEW_CONSOLE);
+-- 
+2.5.0
+

--- a/patches/3.7/0003-mpdecimal-Export-inlined-functions-to-support-extens.patch
+++ b/patches/3.7/0003-mpdecimal-Export-inlined-functions-to-support-extens.patch
@@ -1,0 +1,36 @@
+From 12cd7e4b43f85822d8ab0531cb3097e5f32bd5ff Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Mon, 6 Nov 2017 11:27:32 -0500
+Subject: [PATCH 3/3] mpdecimal: Export inlined functions to support extension
+ built-in on windows
+
+This commit ensures that symbols are available when building _freeze_importlib
+with all extensions built-in on windows.
+
+It addresses the following link error associated
+with CMakeBuild\libpython\_freeze_importlib.vcxproj:
+
+  3>_decimal.obj : error LNK2019: unresolved external symbol _mpd_del referenced in function _PyDec_AsTuple
+  3>io.obj : error LNK2001: unresolved external symbol _mpd_del
+  3>basearith.obj : error LNK2019: unresolved external symbol _mpd_uint_zero referenced in function __mpd_baseshiftl
+  3>io.obj : error LNK2019: unresolved external symbol _mpd_qresize referenced in function _mpd_qset_string
+---
+ Modules/_decimal/libmpdec/mpdecimal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/_decimal/libmpdec/mpdecimal.c b/Modules/_decimal/libmpdec/mpdecimal.c
+index 328ab92..5812bcd 100644
+--- a/Modules/_decimal/libmpdec/mpdecimal.c
++++ b/Modules/_decimal/libmpdec/mpdecimal.c
+@@ -54,7 +54,7 @@
+ 
+ 
+ #if defined(_MSC_VER)
+-  #define ALWAYS_INLINE __forceinline
++  #define ALWAYS_INLINE extern __forceinline
+ #elif defined(LEGACY_COMPILER)
+   #define ALWAYS_INLINE
+   #undef inline
+-- 
+2.5.0
+

--- a/patches/3.7/README.rst
+++ b/patches/3.7/README.rst
@@ -1,0 +1,10 @@
+* ``0001-Prevent-incorrect-include-of-io.h-found-in-libmpdec-.patch``: Rename header files found in
+  ``Modules/_decimal/libmpdec`` directory to avoid conflicts with system headers of the same name.
+
+* ``0002-Prevent-duplicated-OverlappedType-symbols-with-built.patch``: Prevent duplicated OverlappedType
+  symbols with built-in extension on Windows.
+
+* ``0003-mpdecimal-Export-inlined-functions-to-support-extens.patch``: Export inlined functions to
+  support extension built-in on Windows.
+
+


### PR DESCRIPTION
Python 3.7.4 WORKING on Linux and Windows for release and debug.

Apple should not take much to fix _ctypes, if needed.

Next step: make the 3.7 changes backwards compatible.

Ex
config_3.c.in
```
-    {"_imp", PyInit_imp},
+    {"_imp", PyInit__imp}, /* 3.7 was single _ */
```
> Need some #define incantations to work with previous python versions.

This pull shows as separate commits the changes needed to run 3.7. 