### PR TITLE
cmake: Support building nis module on system having libtirpc

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -107,6 +107,9 @@ endif()
 find_path(SQLITE3_INCLUDE_PATH sqlite3.h)
 find_library(SQLITE3_LIBRARY sqlite3)
 
+find_path(TIRPC_RPC_INCLUDE_PATH rpc.h PATHS "/usr/include/tirpc/rpc")
+find_library(TIRPC_LIBRARY tirpc)
+
 if(WIN32)
   set(M_LIBRARIES )
   set(HAVE_LIBM 1)
@@ -2495,3 +2498,4 @@ endif()
 if(CMAKE_SYSTEM MATCHES Windows)
   set(PY_PLATFORM win32)
 endif()
+

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -147,7 +147,23 @@ endif()
 # UNIX-only extensions
 add_python_extension(fcntl REQUIRES UNIX SOURCES fcntlmodule.c)
 add_python_extension(grp REQUIRES UNIX SOURCES grpmodule.c)
-add_python_extension(nis REQUIRES UNIX HAVE_LIBNSL SOURCES nismodule.c LIBRARIES ${HAVE_LIBNSL})
+
+set(nis_REQUIRES UNIX HAVE_LIBNSL)
+set(nis_LIBRARIES ${HAVE_LIBNSL})
+set(nis_INCLUDEDIRS )
+if(TIRPC_LIBRARY AND TIRPC_RPC_INCLUDE_PATH)
+    # if rpc.h is provided by libtirpc (instead of being provided by glibc). See python/cpython#5137
+    list(APPEND nis_REQUIRES )
+    list(APPEND nis_LIBRARIES ${TIRPC_LIBRARY})
+    list(APPEND nis_INCLUDEDIRS ${TIRPC_RPC_INCLUDE_PATH}/../)
+endif()
+add_python_extension(nis
+    REQUIRES ${nis_REQUIRES}
+    SOURCES nismodule.c
+    LIBRARIES ${nis_LIBRARIES}
+    INCLUDEDIRS ${nis_INCLUDEDIRS}
+)
+
 add_python_extension(posix REQUIRES UNIX BUILTIN SOURCES posixmodule.c)
 add_python_extension(pwd REQUIRES UNIX BUILTIN SOURCES pwdmodule.c) # this is needed to find out the user's home dir if $HOME is not set
 add_python_extension(resource REQUIRES UNIX SOURCES resource.c)


### PR DESCRIPTION
glibc has removed Sun RPC. Use replacement libtirpc headers and library in
nis moduleupdated path for rpc.h for systems using libtirpc

See https://github.com/python/cpython/pull/5137

This closes #224

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillion@kitware.com>