### PR TITLE
Add support for building with lzma

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ options on the commandline with `-DOPTION=VALUE`, or use the "ccmake" gui.
       CODECS_ISO2022 CODECS_JP CODECS_KR CODECS_TW COLLECTIONS CPICKLE CRYPT
       CSTRINGIO CSV CTYPES CTYPES_TEST CURSES CURSES_PANEL DATETIME DBM
       ELEMENTTREE FCNTL FUNCTOOLS FUTURE_BUILTINS GDBM GRP HASHLIB HEAPQ
-      HOTSHOT IO ITERTOOLS JSON LINUXAUDIODEV LOCALE LSPROF MATH MMAP
+      HOTSHOT IO ITERTOOLS JSON LINUXAUDIODEV LOCALE LSPROF LZMA MATH MMAP
       MULTIBYTECODEC MULTIPROCESSING NIS NT OPERATOR OSSAUDIODEV PARSER POSIX
       PWD PYEXPAT RANDOM READLINE RESOURCE SELECT SOCKET SPWD SQLITE3 SSL
       STROP STRUCT SYSLOG TERMIOS TESTCAPI TIME TKINTER UNICODEDATA ZLIB
@@ -208,6 +208,11 @@ options on the commandline with `-DOPTION=VALUE`, or use the "ccmake" gui.
     If set to OFF, no attempt to detect GDBM libraries will be done.
     Associated python extensions are: DBM, GDBM
     Following CMake variables can manually be set: GDBM_INCLUDE_PATH, GDBM_LIBRARY, GDBM_COMPAT_LIBRARY
+
+  USE_SYSTEM_LZMA=ON|OFF     (defaults to ON)
+    If set to OFF, no attempt to detect LZMA libraries will be done.
+    Associated python extensions are: LZMA
+    Following CMake variables can manually be set: LZMA_INCLUDE_PATH, LZMA_LIBRARY
 
   USE_SYSTEM_READLINE=ON|OFF    (defaults to ON)
     If set to OFF, no attempt to detect Readline libraries will be done.

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -94,6 +94,9 @@ if(USE_SYSTEM_GDBM)
     endif()
 endif()
 
+find_path(LZMA_INCLUDE_PATH lzma.h)
+find_library(LZMA_LIBRARY lzma)
+
 if(USE_SYSTEM_READLINE)
     if(USE_LIBEDIT)
         find_path(READLINE_INCLUDE_PATH editline/readline.h)

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -657,6 +657,13 @@ add_python_extension(_hashlib
 if(ENABLE_HASHLIB AND CMAKE_C_COMPILER_ID MATCHES GNU)
     set_property(SOURCE ${SRC_DIR}/Modules/_hashopenssl.c PROPERTY COMPILE_FLAGS -Wno-deprecated-declarations)
 endif()
+add_python_extension(_lzma
+    REQUIRES LZMA_INCLUDE_PATH LZMA_LIBRARY
+    SOURCES _lzmamodule.c
+    DEFINITIONS MODULE_NAME="lzma" LZMA_API_STATIC=1
+    INCLUDEDIRS ${LZMA_INCLUDE_PATH}
+    LIBRARIES ${LZMA_LIBRARY}
+)
 add_python_extension(readline
     REQUIRES READLINE_INCLUDE_PATH READLINE_LIBRARY CURSES_LIBRARIES HAVE_READLINE_READLINE_H
     SOURCES readline.c


### PR DESCRIPTION
A number of of Python packages complained that lzma package was not available (displayed a warning or refused to load), such as pandas, skimage, meshio.

Now if LZMA_LIBRARY:FILEPATH and LZMA_INCLUDE_PATH:PATH CMake variables are set then Python is build with lzma support.
Tested with lzma implementation that uses CMake build system: https://github.com/nextgis-borsch/lib_lzma.git