### PR TITLE
Skip CMP0045 setting on CMake >= 3.0.1

### DIFF
--- a/cmake/CMakeExpandImportedTargets.cmake
+++ b/cmake/CMakeExpandImportedTargets.cmake
@@ -52,9 +52,11 @@ function(CMAKE_EXPAND_IMPORTED_TARGETS _RESULT )
       endif()
    endif()
 
-   # XXX ignore warning 'get_target_property() called with non-existent target'
-   if(POLICY CMP0045)
-     cmake_policy(SET CMP0045 OLD)
+   if(CMAKE_VERSION VERSION_LESS 3.0.1)
+      # XXX ignore warning 'get_target_property() called with non-existent target'
+      if(POLICY CMP0045)
+         cmake_policy(SET CMP0045 OLD)
+      endif()
    endif()
 
    # handle imported library targets


### PR DESCRIPTION
The policy CMP0045 is set to old because of a CMake bug, which was fixed in CMake 3.0.1, we don't need the CMP0045 setting any more. Also, on newer CMake, this line is triggering a warning about CMP0045 will be removed in the future.