### PR TITLE
Initial Android Support: alternate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,7 +576,7 @@ if(UNIX)
 
     # Makefile
     set(MAKEFILE_LDSHARED_FLAGS "-shared")
-    if(APPLE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set(MAKEFILE_LDSHARED_FLAGS "-dynamiclib -headerpad_max_install_names -undefined dynamic_lookup")
     endif()
     configure_file(cmake/makefile-variables.in

--- a/README.rst
+++ b/README.rst
@@ -255,22 +255,10 @@ Guide <https://developer.android.com/ndk/guides/cmake>`_).
 .. code:: bash
 
   # Unix
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/scratch/python-install -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi-v7a -DCMAKE_CROSSCOMPILING_EMULATOR=adb-emu.sh -DANDROID_ALLOW_UNDEFINED_SYMBOLS=On -DENABLE_DECIMAL=Off -DENABLE_CTYPES=Off -DANDROID_PLATFORM=21 ../python-cmake-buildsystem
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/scratch/python-install -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi-v7a -DCMAKE_CROSSCOMPILING_EMULATOR=../python-cmake-buildsystem/run_on_android.sh -DANDROID_ALLOW_UNDEFINED_SYMBOLS=On -DENABLE_DECIMAL=Off -DENABLE_CTYPES=Off -DANDROID_PLATFORM=21 ../python-cmake-buildsystem
 
-adb-emu.sh sends executable configuration files and launches them on connected device or launched
-emulator. Ensure device or emulator have same architecture you builds python:
-
-.. code:: bash
-
-  #!/bin/sh
-  adb push "$1" /data/local/tmp/ 1>/dev/null 2>/dev/null
-  if [ $# -eq 1 ]; then
-    adb shell /data/local/tmp/$(basename $1)
-  elif [ $# -eq 3 ]; then
-    adb push "$2" /data/local/tmp/ 1>/dev/null 2>/dev/null
-    adb shell /data/local/tmp/$(basename $1) /data/local/tmp/$(basename $2) /data/local/tmp/$(basename $3)
-    adb pull /data/local/tmp/$(basename $3) "$3" 1>/dev/null 2>/dev/null
-  fi
+run_on_android.sh sends executable configuration files and launches them on connected device or launched
+emulator. Ensure device or emulator have same architecture you builds python.
 
 Remarks
 -------

--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,32 @@ these before running make::
   patch -p0 < cmake/patches-win32/02-signalmodule.patch
   patch -p0 < cmake/patches-win32/03-mingw32.patch
 
+Cross-compiling for Android from Linux (unsupported)
+....................................................
+
+To build Python with Android NDK set up emulator, toolchain and ABI (see `Android CMake
+Guide <https://developer.android.com/ndk/guides/cmake>`_).
+
+.. code:: bash
+
+  # Unix
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/scratch/python-install -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi-v7a -DCMAKE_CROSSCOMPILING_EMULATOR=adb-emu.sh -DANDROID_ALLOW_UNDEFINED_SYMBOLS=On -DENABLE_DECIMAL=Off -DENABLE_CTYPES=Off -DANDROID_PLATFORM=21 ../python-cmake-buildsystem
+
+adb-emu.sh sends executable configuration files and launches them on connected device or launched
+emulator. Ensure device or emulator have same architecture you builds python:
+
+.. code:: bash
+
+  #!/bin/sh
+  adb push "$1" /data/local/tmp/ 1>/dev/null 2>/dev/null
+  if [ $# -eq 1 ]; then
+    adb shell /data/local/tmp/$(basename $1)
+  elif [ $# -eq 3 ]; then
+    adb push "$2" /data/local/tmp/ 1>/dev/null 2>/dev/null
+    adb shell /data/local/tmp/$(basename $1) /data/local/tmp/$(basename $2) /data/local/tmp/$(basename $3)
+    adb pull /data/local/tmp/$(basename $3) "$3" 1>/dev/null 2>/dev/null
+  fi
+
 Remarks
 -------
 

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -215,7 +215,12 @@ check_include_files(grp.h HAVE_GRP_H)
 check_include_files(ieeefp.h HAVE_IEEEFP_H)
 check_include_files(inttypes.h HAVE_INTTYPES_H) # libffi and cpython
 check_include_files(io.h HAVE_IO_H)
-check_include_files(langinfo.h HAVE_LANGINFO_H)
+if (${CMAKE_SYSTEM_NAME} MATCHES "^Android")
+  set(HAVE_LANGINFO_H 0) # Android cann't link functions from langinfo.h
+else()
+  check_include_files(langinfo.h HAVE_LANGINFO_H)
+endif()
+
 check_include_files(libintl.h HAVE_LIBINTL_H)
 check_include_files(libutil.h HAVE_LIBUTIL_H)
 check_include_files(linux/tipc.h HAVE_LINUX_TIPC_H)
@@ -362,6 +367,11 @@ set(LIBUTIL_LIBRARIES )
 set(LIBUTIL_EXPECTED 1)
 
 if(CMAKE_SYSTEM MATCHES "VxWorks\\-7$")
+  set(LIBUTIL_EXPECTED 0)
+  set(HAVE_LIBUTIL 0)
+endif()
+
+if(CMAKE_SYSTEM MATCHES "^Android")
   set(LIBUTIL_EXPECTED 0)
   set(HAVE_LIBUTIL 0)
 endif()

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -161,11 +161,16 @@ endif()
 message(STATUS "${_msg} - ${ABIFLAGS}")
 
 set(_msg "Checking SOABI")
-try_run(PLATFORM_RUN PLATFORM_COMPILE
-        ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/platform.c
-        RUN_OUTPUT_VARIABLE PLATFORM_TRIPLET)
-if(NOT PLATFORM_COMPILE)
-  message(FATAL_ERROR "We could not determine the platform. Please clean the ${CMAKE_PROJECT_NAME} environment and try again...")
+set(PLATFORM_TRIPLET )
+if (ANDROID)
+    set(PLATFORM_TRIPLET "${CMAKE_ANDROID_ARCH_ABI}-linux-android")
+else()
+    try_run(PLATFORM_RUN PLATFORM_COMPILE
+            ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/platform.c
+            RUN_OUTPUT_VARIABLE PLATFORM_TRIPLET)
+    if(NOT PLATFORM_COMPILE)
+        message(FATAL_ERROR "We could not determine the platform. Please clean the ${CMAKE_PROJECT_NAME} environment and try again...")
+    endif()
 endif()
 set(SOABI "cpython-${PY_VERSION_MAJOR}${PY_VERSION_MINOR}${ABIFLAGS}-${PLATFORM_TRIPLET}")
 
@@ -1147,8 +1152,9 @@ check_c_source_compiles("
 int main() {int a = MAP_ANONYMOUS;}"
 HAVE_MMAP_ANON)
 
-# libffi specific: Check for /dev/zero support for anonymous memory maps
-check_c_source_runs("
+# libffi specific: Check for /dev/zero support as a fallback for anonymous memory maps
+if(NOT HAVE_MMAP_ANON)
+    check_c_source_runs("
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/mman.h>
@@ -1166,6 +1172,7 @@ int main(void) {
   }
   exit(0);
 }" HAVE_MMAP_DEV_ZERO)
+endif()
 
 if(IS_PY3)
 

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -967,60 +967,38 @@ endif()
 # Check for various properties of floating point
 #
 #######################################################################
-
-# Check whether C doubles are little-endian IEEE 754 binary64
-set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_little_endian_double.c)
-file(WRITE ${check_src} "#include <string.h>
-int main() {
-    double x = 9006104071832581.0;
-    if (memcmp(&x, \"\\x05\\x04\\x03\\x02\\x01\\xff\\x3f\\x43\", 8) == 0)
-        return 0;
-    else
-        return 1;
-}
-")
-python_platform_test_run(
-  DOUBLE_IS_LITTLE_ENDIAN_IEEE754
-  "Checking whether C doubles are little-endian IEEE 754 binary64"
-  ${check_src}
-  DIRECT
-  )
-
-# Check whether C doubles are big-endian IEEE 754 binary64
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_big_endian_double.c)
-file(WRITE ${check_src} "#include <string.h>
-int main() {
-    double x = 9006104071832581.0;
-    if (memcmp(&x, \"\\x43\\x3f\\xff\\x01\\x02\\x03\\x04\\x05\", 8) == 0)
-        return 0;
-    else
-        return 1;
-}
+file(WRITE ${check_src} "
+double d = 90904234967036810337470478905505011476211692735615632014797120844053488865816695273723469097858056257517020191247487429516932130503560650002327564517570778480236724525140520121371739201496540132640109977779420565776568942592.0;
 ")
-python_platform_test_run(
-  DOUBLE_IS_BIG_ENDIAN_IEEE754
-  "Checking whether C doubles are big-endian IEEE 754 binary64"
-  ${check_src}
-  DIRECT
-  )
 
-# Check whether C doubles are ARM mixed-endian IEEE 754 binary64
-set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_mixed_endian_double.c)
-file(WRITE ${check_src} "#include <string.h>
-int main() {
-    double x = 9006104071832581.0;
-    if (memcmp(&x, \"\\x01\\xff\\x3f\\x43\\x05\\x04\\x03\\x02\", 8) == 0)
-        return 0;
-    else
-        return 1;
-}
-")
-python_platform_test_run(
-  DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754
-  "Checking doubles are ARM mixed-endian IEEE 754 binary64"
-  ${check_src}
-  DIRECT
-  )
+# TODO: factorize this try_compile statement
+try_compile(DOUBLE_BIG_ENDIAN_TEST_COMPILED
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${check_src}
+        COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+        COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+        CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
+        "${CHECK_C_SOURCE_COMPILES_ADD_LIBRARIES}"
+        "${CHECK_C_SOURCE_COMPILES_ADD_INCLUDES}"
+        COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/double_big_endian.bin)
+
+if(DOUBLE_BIG_ENDIAN_TEST_COMPILED)
+    file(READ ${CMAKE_CURRENT_BINARY_DIR}/double_big_endian.bin DOUBLE_BIG_ENDIAN_DATA)
+    string(FIND ${DOUBLE_BIG_ENDIAN_DATA} "noonsees" NOONSEES)
+    if(NOONSEES)
+        set(DOUBLE_IS_BIG_ENDIAN_IEEE754 1)
+        set(DOUBLE_IS_LITTLE_ENDIAN_IEEE754 0)
+    else()
+        string(FIND ${DOUBLE_BIG_ENDIAN_DATA} "seesnoon" SEESNOON)
+        if(SEESNOON)
+            set(DOUBLE_IS_BIG_ENDIAN_IEEE754 0)
+            set(DOUBLE_IS_LITTLE_ENDIAN_IEEE754 1)
+        else()
+            message(WARNING "Could not determine if double precision floats endianness")
+        endif()
+    endif()
+endif()
 
 # The short float repr introduced in Python 3.1 requires the
 # correctly-rounded string <-> double conversion functions from

--- a/cmake/Extensions.cmake
+++ b/cmake/Extensions.cmake
@@ -195,7 +195,7 @@ function(add_python_extension name)
             )
         endif()
 
-        if(APPLE)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
             set_target_properties(${target_name} PROPERTIES
                 LINK_FLAGS -Wl,-undefined,dynamic_lookup
                 SUFFIX .so

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -477,19 +477,19 @@ endif()
 
 if(ENABLE_DECIMAL)
     message(STATUS "extension_decimal: libmpdec_config [${libmpdec_config}]")
-endif()
-add_python_extension(_decimal
-    SOURCES
-        _decimal/_decimal.c
-        _decimal/docstrings.h
-        ${_decimal_EXTRA_SOURCES}
-    DEFINITIONS ${libmpdec_config_${libmpdec_config}}
-    ${_decimal_REQUIRES}
-    ${_decimal_LIBRARIES}
-    ${_decimal_INCLUDEDIRS}
-)
-if(_decimal_compile_flags AND NOT BUILTIN_DECIMAL)
-    set_target_properties(extension_decimal PROPERTIES COMPILE_FLAGS ${_decimal_compile_flags})
+    add_python_extension(_decimal
+            SOURCES
+            _decimal/_decimal.c
+            _decimal/docstrings.h
+            ${_decimal_EXTRA_SOURCES}
+            DEFINITIONS ${libmpdec_config_${libmpdec_config}}
+            ${_decimal_REQUIRES}
+            ${_decimal_LIBRARIES}
+            ${_decimal_INCLUDEDIRS}
+            )
+    if(_decimal_compile_flags AND NOT BUILTIN_DECIMAL)
+        set_target_properties(extension_decimal PROPERTIES COMPILE_FLAGS ${_decimal_compile_flags})
+    endif()
 endif()
 
 endif()

--- a/cmake/lib/CMakeLists.txt
+++ b/cmake/lib/CMakeLists.txt
@@ -43,20 +43,22 @@ endif()
 
 # Generate grammar tables in install directory
 # XXX Should a custom target be added to generate file at built time ?
-install(CODE "find_program(
-  PYTHON_EXECUTABLE python
-  HINTS \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}
-  NO_DEFAULT_PATH)
-set(wrapper)
-if(UNIX)
-  set(_envvar LD_LIBRARY_PATH)
-  if(APPLE)
-    set(_envvar DYLD_LIBRARY_PATH)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "^Android")
+  install(CODE "find_program(
+    PYTHON_EXECUTABLE python
+    HINTS \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}
+    NO_DEFAULT_PATH)
+  set(wrapper)
+  if(UNIX)
+    set(_envvar LD_LIBRARY_PATH)
+    if(APPLE)
+      set(_envvar DYLD_LIBRARY_PATH)
+    endif()
+    set(wrapper env \${_envvar}=\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBPYTHON_LIBDIR})
   endif()
-  set(wrapper env \${_envvar}=\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBPYTHON_LIBDIR})
+  execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
+    \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/Grammar.txt)
+  execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
+    \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/PatternGrammar.txt)
+  ")
 endif()
-execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
-  \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/Grammar.txt)
-execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
-  \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/PatternGrammar.txt)
-")

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -395,41 +395,45 @@ set(LIBPYTHON_FROZEN_SOURCES )
 if(IS_PY3)
 
 # Build _freeze_importlib executable
-add_executable(_freeze_importlib
-  ${SRC_DIR}/Programs/_freeze_importlib.c
-  ${LIBPYTHON_OMIT_FROZEN_SOURCES}
-  )
-target_link_libraries(_freeze_importlib ${LIBPYTHON_TARGET_LIBRARIES})
-if(builtin_compile_definitions_without_py_limited_api)
-  target_compile_definitions(_freeze_importlib PUBLIC ${builtin_compile_definitions_without_py_limited_api})
-endif()
+if(NOT CMAKE_CROSSCOMPILING)
+    add_executable(_freeze_importlib
+      ${SRC_DIR}/Programs/_freeze_importlib.c
+      ${LIBPYTHON_OMIT_FROZEN_SOURCES}
+      )
+    target_link_libraries(_freeze_importlib ${LIBPYTHON_TARGET_LIBRARIES})
+    if(builtin_compile_definitions_without_py_limited_api)
+      target_compile_definitions(_freeze_importlib PUBLIC ${builtin_compile_definitions_without_py_limited_api})
+    endif()
 
-# Freeze modules
-set(LIBPYTHON_FROZEN_SOURCES
-  ${SRC_DIR}/Python/importlib_external.h
-  ${SRC_DIR}/Python/importlib.h
-)
-add_custom_command(
-  OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
-  COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
-      ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
+    # Freeze modules
+    set(LIBPYTHON_FROZEN_SOURCES
       ${SRC_DIR}/Python/importlib_external.h
-  COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
-      ${SRC_DIR}/Lib/importlib/_bootstrap.py
       ${SRC_DIR}/Python/importlib.h
-  DEPENDS
-    _freeze_importlib
-    ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
-    ${SRC_DIR}/Lib/importlib/_bootstrap.py
-)
+    )
+    add_custom_command(
+      OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
+      COMMAND
+        ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+          ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
+          ${SRC_DIR}/Python/importlib_external.h
+      COMMAND
+        ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+          ${SRC_DIR}/Lib/importlib/_bootstrap.py
+          ${SRC_DIR}/Python/importlib.h
+      DEPENDS
+        _freeze_importlib
+        ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
+        ${SRC_DIR}/Lib/importlib/_bootstrap.py
+    )
 
-# This is a convenience target allowing to regenerate
-# the frozen sources.
-add_custom_target(freeze_modules DEPENDS ${LIBPYTHON_FROZEN_SOURCES})
-
-endif()
+    # This is a convenience target allowing to regenerate
+    # the frozen sources.
+    add_custom_target(freeze_modules DEPENDS ${LIBPYTHON_FROZEN_SOURCES})
+else(NOT CMAKE_CROSSCOMPILING)
+    # KLUDGE: suppose importlib.h and importlib_external.h are already present.
+    add_custom_target(freeze_modules)
+endif(NOT CMAKE_CROSSCOMPILING)
+endif(IS_PY3)
 
 # Build pgen executable
 set(PGEN2_SOURCES

--- a/cmake/platform.c
+++ b/cmake/platform.c
@@ -18,16 +18,28 @@ char *PLATFORM_TRIPLET =
 
 #if defined(__linux__)
 # if defined(__x86_64__) && defined(__LP64__)
+#  if defined(__ANDROID_NDK__)
+        "x86_64-linux-android"
+#  else
         "x86_64-linux-gnu"
+#  endif
 # elif defined(__x86_64__) && defined(__ILP32__)
         "x86_64-linux-gnux32"
 # elif defined(__i386__)
+#  if defined(__ANDROID_NDK__)
+        "i686-linux-android"
+#  else
         "i386-linux-gnu"
+#  endif
 # elif defined(__aarch64__) && defined(__AARCH64EL__)
 #  if defined(__ILP32__)
         "aarch64_ilp32-linux-gnu"
 #  else
+#   if defined(__ANDROID_NDK__)
+        "aarch64-linux-android"
+#   else
         "aarch64-linux-gnu"
+#   endif
 #  endif
 # elif defined(__aarch64__) && defined(__AARCH64EB__)
 #  if defined(__ILP32__)
@@ -45,7 +57,11 @@ char *PLATFORM_TRIPLET =
 #  endif
 # elif defined(__ARM_EABI__) && !defined(__ARM_PCS_VFP)
 #  if defined(__ARMEL__)
+#   if defined(__ANDROID_NDK__)
+        "arm-linux-androideabi"
+#   else
         "arm-linux-gnueabi"
+#   endif
 #  else
         "armeb-linux-gnueabi"
 #  endif

--- a/cmake/python/CMakeLists.txt
+++ b/cmake/python/CMakeLists.txt
@@ -48,7 +48,7 @@ if(WIN32)
         )
 endif()
 
-if(UNIX AND PY_VERSION VERSION_GREATER "2.7.4")
+if(UNIX AND PY_VERSION VERSION_GREATER "2.7.4" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "^Android")
     # Setup landmark allowing to run the interpreter from a build tree. See 'getpath.c' for details.
     set(_sysconfigdata_py "_sysconfigdata.py")
     if("${PY_VERSION}" VERSION_EQUAL "3.6.0" OR "${PY_VERSION}" VERSION_GREATER "3.6.0")

--- a/run_on_android.sh
+++ b/run_on_android.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+adb push "$1" /data/local/tmp/ 1>/dev/null 2>/dev/null
+if [ $# -eq 1 ]; then
+  adb shell /data/local/tmp/$(basename $1)
+elif [ $# -eq 3 ]; then
+  adb push "$2" /data/local/tmp/ 1>/dev/null 2>/dev/null
+  adb shell /data/local/tmp/$(basename $1) /data/local/tmp/$(basename $2) /data/local/tmp/$(basename $3)
+  adb pull /data/local/tmp/$(basename $3) "$3" 1>/dev/null 2>/dev/null
+fi


### PR DESCRIPTION
Hello,
I have been using the branch by @o01eg to build Python for Android (from this PR: https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/262) and managed to make it work with some extra changes.
I hope this set of changes will be interesting as well.

To avoid requiring to connect to a target device while building (which is hard to achieve on simpler buildfarms), I had to provide certain definitions manually. I tested the build with the following definitions:

```
"-DBUILD_EXTENSIONS_AS_BUILTIN=ON", // Have the extensions built in the Python library.
"-DANDROID_ALLOW_UNDEFINED_SYMBOLS=ON", // Required because of how Python builds its extensions.

// Remove content or features we do not need.
"-DINSTALL_MANUAL=OFF",
"-DINSTALL_TEST=OFF",
"-DINSTALL_DEVELOPMENT=OFF",
"-DWITH_DOC_STRINGS=OFF",

// Disable some Python extensions that are not supported.
"-DENABLE_CTYPES=OFF",
"-DENABLE_DECIMAL=OFF",
"-DENABLE_GRP=OFF",

// KLUDGE: assuming some properties of the target platform to avoid running
// programs on a target device to deduce them.
"-DX87_DOUBLE_ROUNDING=OFF",
"-DTANH_PRESERVES_ZERO_SIGN=ON",
"-DLOG1P_DROPS_ZERO_SIGN=ON",
"-DPOSIX_SEMAPHORES_NOT_ENABLED=OFF",
"-DHAVE_BROKEN_SEM_GETVALUE=OFF",
"-DHAVE_BROKEN_NICE=OFF",
"-DHAVE_BROKEN_POLL=OFF",
"-DHAVE_WORKING_TZSET=ON",
"-DHAVE_ALIGNED_REQUIRED=ON",
"-DHAVE_BROKEN_MBSTOWCS=OFF",
"-DHAVE_COMPUTED_GOTOS=OFF",
"-DHAVE_GLIBC_MEMMOVE_BUG=OFF",
"-DHAVE_LONG_LONG_FORMAT=OFF",
"-DHAVE_SIZE_T_FORMAT=OFF",
```