### PR TITLE
Fix install specifying DESTDIR env. var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,7 @@ endif()
 # to go in there.  bin/python uses this to auto-determine the exec_prefix
 # and properly generate the _sysconfigdata.py
 file(MAKE_DIRECTORY "${EXTENSION_BUILD_DIR}")
-install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${EXTENSION_INSTALL_DIR}\")")
+install(DIRECTORY DESTINATION ${EXTENSION_INSTALL_DIR})
 
 if(BUILD_TESTING)
     set(TESTOPTS -l)


### PR DESCRIPTION
This commit restores the support for specifying DESTDIR
env. variable when building "install" target associated
with "Unix Makefiles" generated build-system:

```
$ DESTIR=/path/to/install make install
```

See https://cmake.org/cmake/help/latest/envvar/DESTDIR.html