### PR TITLE
cmake: Fix undefined reference to gss_* symbols when libkrb5-dev package not installed

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -2480,7 +2480,10 @@ if(WITH_STATIC_DEPENDENCIES AND TIRPC_LIBRARY)
       set(_tirpc_library_static_dependencies_required 1)
       set(_tirpc_static_libraries ${GSSAPI_KRB5_STATIC_LIBRARY})
     endif()
-
+  else()
+    # If shared library can't be found, we assume the static library is required.
+    set(_tirpc_library_static_dependencies_required 1)
+    set(_tirpc_static_libraries ${GSSAPI_KRB5_STATIC_LIBRARY})
   endif()
 
 endif()


### PR DESCRIPTION
This commit is a follow-up of f929319a9 (cmake: Fix undefined reference to
gss_* symbols when WITH_STATIC_DEPENDENCIES is ON).

If the shared library "libgssapi_krb5.so" can't be found, the build-system
is updated to assume the static libraries are required.

Indeed, without installing the "libkrb5-dev" package, the shared library
"libgssapi_krb5.so" can't be found and the test checking if the tirpc
library was build with or without the gssapi feature can not be performed.

See #227 and #285