### PR TITLE
3.7.x: Fix incorrect PYTHONFRAMEWORK value returned by sysconfig.get_config_var

### DIFF
--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1755,10 +1755,7 @@
 /* Define if you have POSIX threads, and your system does not define that. */
 #cmakedefine _POSIX_THREADS
 
-/* framework name [Python <= 3.6] */
-#define PYTHONFRAMEWORK "@PYTHONFRAMEWORK@"
-
-/* framework name [Python >= 3.7] */
+/* framework name [Python 3.7] */
 #define _PYTHONFRAMEWORK "@PYTHONFRAMEWORK@"
 
 /* Define to force use of thread-safe errno, h_errno, and other functions */


### PR DESCRIPTION
This commit fixes a regression introduced in 97631f223 (Add support for
building Python 3.7.x) where it was incorrectly assumed that PYTHONFRAMEWORK
existed for Python 3.6.

It turns out that the prior value in pyconfig.h.in was introduced
in python/cpython@a8f8d5b4b (bpo-29585: optimize site.py startup time (GH-136))
while working toward cpython 3.7 and just before python/cpython@6b42eb176
(bpo-29585: Fix sysconfig.get_config_var("PYTHONFRAMEWORK") (GH-2483)) intoducing
_PYTHONFRAMEWORK and avoiding incorrect value returned by sysconfig.get_config_var.

Co-authored-by: Issam E. Maghni <issam.e.maghni@mailbox.org>