### PR TITLE
_testconsole: Fix link error when attempting to build extension as builtin on Linux

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -126,7 +126,7 @@ if(PY_VERSION VERSION_GREATER_EQUAL "3.6")
     )
     add_python_extension(_blake2 ${WIN32_BUILTIN} SOURCES ${_blake2_SOURCES})
     add_python_extension(_sha3 ${WIN32_BUILTIN} SOURCES _sha3/sha3module.c)
-    add_python_extension(_testconsole ${WIN32_BUILTIN} SOURCES ../PC/_testconsole.c)
+    add_python_extension(_testconsole ${WIN32_BUILTIN} REQUIRES WIN32 SOURCES ../PC/_testconsole.c)
 endif()
 
 # Python 3.7


### PR DESCRIPTION
This commit fixes a regression introduced in e0017a7 (3.6.x: Add support
for building _testconsole module) ensuring the module is excluded on platform
different from windows.

It fixes the following error when building with BUILD_EXTENSIONS_AS_BUILTIN
enabled on Linux:

```
  CMakeFiles/_freeze_importlib.dir/__/__/CMakeFiles/config.c.o:(.data+0x308): undefined reference to `PyInit__testconsole'
```