### PR TITLE
Use latest patch versions for testing and default version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,26 +86,26 @@ jobs:
 workflows:
     build-and-test:
       jobs:
-        # 3.9.9
+        # 3.9.10
         - build-test-python:
-            name: python-3.9.9-x64
-            python_version: 3.9.9
+            name: python-3.9.10-x64
+            python_version: 3.9.10
             python_arch: x64
 
         - build-test-python:
-            name: python-3.9.9-x86
-            python_version: 3.9.9
+            name: python-3.9.10-x86
+            python_version: 3.9.10
             python_arch: x86
 
-        # 3.8.5
+        # 3.8.12
         - build-test-python:
-            name: python-3.8.5-x64
-            python_version: 3.8.5
+            name: python-3.8.12-x64
+            python_version: 3.8.12
             python_arch: x64
 
         - build-test-python:
-            name: python-3.8.5-x86
-            python_version: 3.8.5
+            name: python-3.8.12-x86
+            python_version: 3.8.12
             python_arch: x86
 
         # 3.7.12
@@ -144,17 +144,17 @@ workflows:
 
     build-and-test-win:
       jobs:
-        # 3.9.9
+        # 3.9.10
         - build-test-python-win:
-            name: python-3.9.9-win-x64
-            python_version: 3.9.9
+            name: python-3.9.10-win-x64
+            python_version: 3.9.10
             python_arch: x64
             generator: "Visual Studio 16 2019"
 
-        # 3.8.5
+        # 3.8.12
         - build-test-python-win:
-            name: python-3.8.5-win-x64
-            python_version: 3.8.5
+            name: python-3.8.12-win-x64
+            python_version: 3.8.12
             python_arch: x64
             generator: "Visual Studio 16 2019"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [macos-10.15]
-        python-version: [3.7.12, 3.8.5, 3.9.9]
+        python-version: [3.7.12, 3.8.12, 3.9.10]
         include:
           - runs-on: macos-10.15
             c-compiler: "clang"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13.5)
 
-set(PYTHON_VERSION "3.9.9" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.9.10" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ How to use this buildsystem:
 
 .. note::
 
-  By default, the build system will download the python 3.9.9 source from
+  By default, the build system will download the python 3.9.10 source from
   http://www.python.org/ftp/python/
 
 
@@ -72,7 +72,7 @@ options on the commandline with `-DOPTION=VALUE`, or use the "ccmake" gui.
 
 ::
 
-  PYTHON_VERSION=major.minor.patch (defaults to 3.9.9)
+  PYTHON_VERSION=major.minor.patch (defaults to 3.9.10)
     The version of Python to build.
 
   PYTHON_APPLY_PATCHES=ON|OFF (defaults to ON)


### PR DESCRIPTION
This is a followup PR to what was discussed at https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/306#issuecomment-1015978067. 

This updates the ci builds to use the latest patch release of each python minor release and also updates the default built to the latest patch release of the latest python minor version currently supported (3.9).