### PR TITLE
Use latest patch versions for testing and default version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,37 +86,37 @@ jobs:
 workflows:
     build-and-test:
       jobs:
-        # 3.9.10
+        # 3.9.17
         - build-test-python:
-            name: python-3.9.10-x64
-            python_version: 3.9.10
+            name: python-3.9.17-x64
+            python_version: 3.9.17
             python_arch: x64
 
         - build-test-python:
-            name: python-3.9.10-x86
-            python_version: 3.9.10
+            name: python-3.9.17-x86
+            python_version: 3.9.17
             python_arch: x86
 
-        # 3.8.12
+        # 3.8.17
         - build-test-python:
-            name: python-3.8.12-x64
-            python_version: 3.8.12
+            name: python-3.8.17-x64
+            python_version: 3.8.17
             python_arch: x64
 
         - build-test-python:
-            name: python-3.8.12-x86
-            python_version: 3.8.12
+            name: python-3.8.17-x86
+            python_version: 3.8.17
             python_arch: x86
 
-        # 3.7.12
+        # 3.7.17
         - build-test-python:
-            name: python-3.7.12-x64
-            python_version: 3.7.12
+            name: python-3.7.17-x64
+            python_version: 3.7.17
             python_arch: x64
 
         - build-test-python:
-            name: python-3.7.12-x86
-            python_version: 3.7.12
+            name: python-3.7.17-x86
+            python_version: 3.7.17
             python_arch: x86
 
         # 3.6.15
@@ -144,24 +144,24 @@ workflows:
 
     build-and-test-win:
       jobs:
-        # 3.9.10
+        # 3.9.17
         - build-test-python-win:
-            name: python-3.9.10-win-x64
-            python_version: 3.9.10
+            name: python-3.9.17-win-x64
+            python_version: 3.9.17
             python_arch: x64
             generator: "Visual Studio 16 2019"
 
-        # 3.8.12
+        # 3.8.17
         - build-test-python-win:
-            name: python-3.8.12-win-x64
-            python_version: 3.8.12
+            name: python-3.8.17-win-x64
+            python_version: 3.8.17
             python_arch: x64
             generator: "Visual Studio 16 2019"
 
-        # 3.7.12
+        # 3.7.17
         - build-test-python-win:
-            name: python-3.7.12-win-x64
-            python_version: 3.7.12
+            name: python-3.7.17-win-x64
+            python_version: 3.7.17
             python_arch: x64
             generator: "Visual Studio 16 2019"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [macos-latest]
-        python-version: [3.7.12, 3.8.12, 3.9.10]
+        python-version: [3.7.17, 3.8.17, 3.9.17]
         include:
           - runs-on: macos-latest
             c-compiler: "clang"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13.5)
 
-set(PYTHON_VERSION "3.9.10" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.9.17" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ How to use this buildsystem:
 
 .. note::
 
-  By default, the build system will download the python 3.9.10 source from
+  By default, the build system will download the python 3.9.17 source from
   http://www.python.org/ftp/python/
 
 
@@ -72,7 +72,7 @@ options on the commandline with `-DOPTION=VALUE`, or use the "ccmake" gui.
 
 ::
 
-  PYTHON_VERSION=major.minor.patch (defaults to 3.9.10)
+  PYTHON_VERSION=major.minor.patch (defaults to 3.9.17)
     The version of Python to build.
 
   PYTHON_APPLY_PATCHES=ON|OFF (defaults to ON)


### PR DESCRIPTION
This is a follow-up to https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/313#issuecomment-1612148459

cc: @jcfr 