### PR TITLE
cmake: Prevent rebuild ensuring SRC_DIR always converted to absolute path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,6 @@ if(NOT (SRC_DIR AND EXISTS ${SRC_DIR}/${_landmark}))
         endif()
     endforeach()
 endif()
-get_filename_component(SRC_DIR "${SRC_DIR}" ABSOLUTE)
 
 # Download sources
 get_filename_component(_parent_dir ${CMAKE_CURRENT_BINARY_DIR} PATH)
@@ -303,6 +302,7 @@ if(NOT EXISTS ${SRC_DIR}/${_landmark} AND DOWNLOAD_SOURCES)
     set(SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/../${_extracted_dir})
 endif()
 
+get_filename_component(SRC_DIR "${SRC_DIR}" ABSOLUTE)
 if(NOT EXISTS ${SRC_DIR}/${_landmark})
     message(FATAL_ERROR "Failed to locate python source.
 The searched locations were:


### PR DESCRIPTION
This commit ensures that the `SRC_DIR` set after extracting the Python source archive is also converted to an absolute path during the initial configuration.