### PR TITLE
style: Strip trailing spaces from CMake files

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -157,7 +157,7 @@ find_library(UUID_LIBRARY uuid)
 if(WIN32)
   set(M_LIBRARIES )
   set(HAVE_LIBM 1)
-  # From PC/pyconfig.h: 
+  # From PC/pyconfig.h:
   #  This is a manually maintained version used for the Watcom,
   #  Borland and Microsoft Visual C++ compilers.  It is a
   #  standard part of the Python distribution.
@@ -642,7 +642,7 @@ elseif(CMAKE_SYSTEM MATCHES "VxWorks\\-7$")
 
   # VxWorks-7
 
-  # On VxWorks-7, defining _XOPEN_SOURCE or _POSIX_C_SOURCE 
+  # On VxWorks-7, defining _XOPEN_SOURCE or _POSIX_C_SOURCE
   # leads to a failure in select.h because sys/types.h fails
   # to define FD_SETSIZE.
   # Reported by Martin Oberhuber as V7COR-4651.
@@ -731,10 +731,10 @@ set(PYTHONFRAMEWORK "")
 
 if(HAVE_LONG_LONG)
   if(SIZEOF_OFF_T GREATER SIZEOF_LONG
-      AND (SIZEOF_LONG_LONG GREATER SIZEOF_OFF_T OR SIZEOF_LONG_LONG EQUAL SIZEOF_OFF_T))      
+      AND (SIZEOF_LONG_LONG GREATER SIZEOF_OFF_T OR SIZEOF_LONG_LONG EQUAL SIZEOF_OFF_T))
       set(HAVE_LARGEFILE_SUPPORT 1)
   endif()
-  
+
 endif()
 
 
@@ -1482,7 +1482,7 @@ foreach(decl isinf isnan isfinite)
 endforeach()
 
 cmake_pop_check_state()
-  
+
 #######################################################################
 #
 # time
@@ -1658,7 +1658,7 @@ endif()
 
 #######################################################################
 #
-# unicode 
+# unicode
 #
 #######################################################################
 
@@ -2319,7 +2319,7 @@ endif()
 
 if(IS_PY2)
 check_c_source_compiles("
-        void f(char*,...)__attribute((format(PyArg_ParseTuple, 1, 2))) {}; 
+        void f(char*,...)__attribute((format(PyArg_ParseTuple, 1, 2))) {};
         int main() {f(NULL);} "
         HAVE_ATTRIBUTE_FORMAT_PARSETUPLE)
 endif()
@@ -2378,7 +2378,7 @@ cmake_pop_check_state()
 endif()
 
 check_c_source_runs("#include <unistd.h>\n int main() {
-        int val1 = nice(1); 
+        int val1 = nice(1);
         if (val1 != -1 && val1 == nice(2)) exit(0);
         exit(1);}" HAVE_BROKEN_NICE)
 
@@ -2388,7 +2388,7 @@ check_c_source_runs(" #include <poll.h>
     int poll_test = poll (&poll_struct, 1, 0);
     if (poll_test < 0) { exit(0); }
     else if (poll_test == 0 && poll_struct.revents != POLLNVAL) { exit(0); }
-    else { exit(1); } }" 
+    else { exit(1); } }"
     HAVE_BROKEN_POLL)
 
 
@@ -2882,7 +2882,7 @@ int main(int argc, char* argv[]){FSIORefNum fRef = 0; return 0;}")
     )
 endif()
 
-# todo 
+# todo
 set(PTHREAD_SYSTEM_SCHED_SUPPORTED 1)
 set(HAVE_DEVICE_MACROS ${HAVE_MAKEDEV})
 


### PR DESCRIPTION
Note that patches have not been updated

Based of:
* https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/340