### PR TITLE
MacOS: skip bundled libffi on non-x86_64

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -382,7 +382,7 @@ if(WIN32)
     endif()
 else()
     if(APPLE)
-        if(NOT USE_SYSTEM_LibFFI)
+        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
             add_python_extension(_ctypes
                 SOURCES ${ctypes_COMMON_SOURCES}
                         _ctypes/malloc_closure.c
@@ -397,6 +397,7 @@ else()
                 DEFINITIONS MACOSX
             )
         else()
+            # non-x86_64 architectures, e.g. arm64 or arm64+x86_64 universal build
             add_python_extension(_ctypes
                 REQUIRES LibFFI_INCLUDE_DIR LibFFI_LIBRARY
                 SOURCES ${ctypes_COMMON_SOURCES}


### PR DESCRIPTION
When cross compiling for arm64 Macs, the bundled cpython libffi throws an unsupported cpu error. This change makes it so that Mac compilation skips the bundled libffi if a system libffi was requested.

This change also now makes it possible to build universal python binaries for x86_64/arm64, though that also requires pre-compiling dependencies (including libffi) from source for both architectures. 