### PR TITLE
cmake: sys.platform should be 'linux' instead of 'linux2'

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -2892,7 +2892,11 @@ endif()
 set(PY_PLATFORM generic)
 
 if(CMAKE_SYSTEM MATCHES Linux)
-  set(PY_PLATFORM linux2)
+  if (PY_VERSION VERSION_LESS 3.3)
+    set(PY_PLATFORM linux2)
+  else()
+    set(PY_PLATFORM linux)
+  endif()
 endif()
 
 if(CMAKE_SYSTEM MATCHES Darwin)

--- a/cmake/lib/CMakeLists.txt
+++ b/cmake/lib/CMakeLists.txt
@@ -4,7 +4,7 @@ set(libdir ${SRC_DIR}/Lib)
 file(GLOB_RECURSE libfiles RELATIVE ${libdir} "${libdir}/*")
 
 if(UNIX)
-    set(plat_subdir "plat-linux2")
+    set(plat_subdir "plat-linux")
 endif()
 
 foreach(file ${libfiles})


### PR DESCRIPTION
'linux2' used to refer to the Linux 2.X kernel, but sys.platform was
changed to just 'linux' for all kernel versions since Python 3.3 circa
2011.

See also: https://github.com/python/cpython/issues/56535
