### PR TITLE
cmake: Fix CDash submission updating CTestConfig to use https

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,7 +1,7 @@
 set(CTEST_PROJECT_NAME "Python")
 set(CTEST_NIGHTLY_START_TIME "3:00:00 UTC")
 
-set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_METHOD "https")
 set(CTEST_DROP_SITE "open.cdash.org")
 set(CTEST_DROP_LOCATION "/submit.php?project=CPython")
 set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
Address error like the following on Windows:

```
[...]
Submit files
   Send to group: Circle-CI-Windows
   SubmitURL: http://
  Set CURLOPT_SSLVERSION to CURL_SSLVERSION_TLSv1_2
  Set CURLOPT_SSL_VERIFYPEER to on
   Upload file: C:/Users/circleci/project/build/Testing/20250415-1739/Test.xml to http://?FileName=circleci-window___3.9.17-x64-Release_#349_52b4f06___20250415-1739-Circle-CI-Windows___XML___Test.xml&build=3.9.17-x64-Release_%23349_52b4f06&site=circleci-window&stamp=20250415-1739-Circle-CI-Windows&MD5=7b920eab13b41b1c986459474c1525e9 Size: 1042
   Error when uploading file: C:/Users/circleci/project/build/Testing/20250415-1739/Test.xml
   Error message was: URL rejected: No host part in the URL
   Problems when submitting via HTTP
[...]
```

And like the following on Linux:

```
[...]
SetCTestConfiguration:BuildDirectory:/work/build
SetCTestConfiguration:SourceDirectory:/work
        Add file: /work/scripts/circle_dashboard.cmake
        Add file: /work/scripts/python_common.cmake
Submit files
   Send to group: Circle-CI
   SubmitURL: http://
  Set CURLOPT_SSLVERSION to CURL_SSLVERSION_TLSv1_2
  Set CURLOPT_SSL_VERIFYPEER to on
   Upload file: /work/build/Testing/20250415-1739/Test.xml to http://?FileName=dockcross%2Flinux-x86:20250324-a3b42cd___3.9.17-i686-linux-gnu_#349_52b4f06___20250415-1739-Circle-CI___XML___Test.xml&build=3.9.17-i686-linux-gnu_%23349_52b4f06&site=dockcross%2Flinux-x86%3A20250324-a3b42cd&stamp=20250415-1739-Circle-CI&MD5=12b4f432d52dbb57d59ce071ca578361 Size: 794004
   Error when uploading file: /work/build/Testing/20250415-1739/Test.xml
   Error message was: URL rejected: No host part in the URL
   Problems when submitting via HTTP
[...]
```