### PR TITLE
cmake: Simplify removing use of IS_PY3, PY3_BUILTIN and PY3_ALWAYS_BUILTIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,9 +113,7 @@ cmake_dependent_option(USE_SYSTEM_ZLIB "Use system ZLIB" ${_use_system_zlib_defa
 cmake_dependent_option(USE_SYSTEM_GDBM "Use system GDBM" ON "USE_SYSTEM_LIBRARIES" OFF)
 cmake_dependent_option(USE_SYSTEM_READLINE "Use system READLINE" ON "USE_SYSTEM_LIBRARIES" OFF)
 cmake_dependent_option(USE_SYSTEM_SQLite3 "Use system SQLITE3" ON "USE_SYSTEM_LIBRARIES" OFF)
-if(IS_PY3)
   cmake_dependent_option(USE_SYSTEM_LIBMPDEC "Use system LIBMPDEC" ON "USE_SYSTEM_LIBRARIES" OFF)
-endif()
 
 cmake_dependent_option(USE_BUILTIN_ZLIB "Use builtin ZLIB" ${_use_builtin_zlib_default} "NOT USE_SYSTEM_ZLIB" OFF)
 
@@ -333,11 +331,8 @@ if(PYTHON_APPLY_PATCHES)
   include(cmake/PythonApplyPatches.cmake)
 endif()
 
-# Convenience boolean variables to easily test python version
-set(IS_PY3 1)
-
 # Enable CXX language to support building of _distutils_findvs extension
-if(WIN32 AND IS_PY3)
+if(WIN32)
   enable_language(CXX)
 endif()
 
@@ -362,10 +357,8 @@ endif()
 option(WITH_COMPUTED_GOTOS "Improve performance enabling the computed goto based dispatch" OFF)
 set(USE_COMPUTED_GOTOS ${WITH_COMPUTED_GOTOS})
 
-if(IS_PY3)
 set(WITH_HASH_ALGORITHM "default" CACHE STRING "Define hash algorithm for str, bytes and memoryview.")
 set_property(CACHE WITH_HASH_ALGORITHM PROPERTY STRINGS "default" "siphash24" "fnv")
-endif()
 
 if(PY_VERSION VERSION_LESS "3.7")
     option(WITH_THREAD "Compile in rudimentary thread support" ON)
@@ -562,7 +555,6 @@ if(BUILD_WININST)
 endif()
 
 # Add target to run "Argument Clinic" over all source files
-if(IS_PY3)
 add_custom_target(clinic
     COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:python> ${SRC_DIR}/Tools/clinic/clinic.py --make
     DEPENDS python
@@ -570,7 +562,6 @@ add_custom_target(clinic
     COMMENT "Running 'Argument Clinic' over all source files"
     VERBATIM
 )
-endif()
 
 # Add target to generate 'Include/graminit.h' and 'Python/graminit.c'
 if(PY_VERSION VERSION_GREATER_EQUAL "3.8")

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -51,7 +51,7 @@ if(USE_SYSTEM_LibFFI)
     message(STATUS "LibFFI_LIBRARY=${LibFFI_LIBRARY}")
 endif()
 
-if(IS_PY3 AND USE_SYSTEM_LIBMPDEC)
+if(USE_SYSTEM_LIBMPDEC)
     find_library(LIBMPDEC_LIBRARY NAMES mpdec libmpdec)
     set(LIBMPDEC_LIBRARIES ${LIBMPDEC_LIBRARY})
     message(STATUS "LIBMPDEC_LIBRARIES=${LIBMPDEC_LIBRARIES}")
@@ -163,7 +163,6 @@ if(WIN32)
   #  standard part of the Python distribution.
 else()
 
-if(IS_PY3)
 set(_msg "Checking WITH_HASH_ALGORITHM option")
 message(STATUS "${_msg}")
 if(WITH_HASH_ALGORITHM STREQUAL "default")
@@ -214,8 +213,6 @@ set(SOABI "cpython-${PY_VERSION_MAJOR}${PY_VERSION_MINOR}${ABIFLAGS}-${PLATFORM_
 
 message(STATUS "${_msg} - ${SOABI}")
 
-endif()
-
 if(PY_VERSION VERSION_GREATER_EQUAL "3.8")
 
 # Alternative SOABI used in debug build to load C extensions built in release mode
@@ -249,9 +246,7 @@ if(NOT HAVE_DIRENT_H)
   check_type_size(DIR HAVE_SYS_DIR_H)
   check_include_files(ndir.h HAVE_NDIR_H)
 endif()
-if(IS_PY3)
   check_symbol_exists("dirfd" "sys/types.h;dirent.h" HAVE_DIRFD)
-endif()
 
 check_include_files(alloca.h HAVE_ALLOCA_H) # libffi and cpython
 check_include_files(asm/types.h HAVE_ASM_TYPES_H)
@@ -284,7 +279,6 @@ add_cond(LINUX_NETLINK_HEADERS HAVE_SYS_SOCKET_H sys/socket.h)
 set(LINUX_NETLINK_HEADERS ${LINUX_NETLINK_HEADERS} linux/netlink.h)
 check_include_files("${LINUX_NETLINK_HEADERS}" HAVE_LINUX_NETLINK_H)
 
-if(IS_PY3)
 set(LINUX_QRTR_HEADERS)
 add_cond(LINUX_QRTR_HEADERS HAVE_ASM_TYPES_H  asm/types.h)
 add_cond(LINUX_QRTR_HEADERS HAVE_SYS_SOCKET_H sys/socket.h)
@@ -302,7 +296,6 @@ check_include_files("${LINUX_CAN_HEADERS};linux/can/raw.h" HAVE_LINUX_CAN_RAW_H)
 set(LINUX_VM_SOCKETS_HEADERS)
 add_cond(LINUX_VM_SOCKETS_HEADERS HAVE_SYS_SOCKET_H sys/socket.h)
 check_include_files("${LINUX_VM_SOCKETS_HEADERS};linux/vm_sockets.h" HAVE_LINUX_VM_SOCKETS_H)
-endif()
 
 check_include_files(mach-o/dyld.h HAVE_MACH_O_DYLD_H)
 check_include_files(memory.h HAVE_MEMORY_H) # libffi and cpython
@@ -365,7 +358,6 @@ check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS) # libffi 
 
 check_include_files(stdarg.h HAVE_STDARG_PROTOTYPES)
 
-if(IS_PY3)
 check_include_files(endian.h HAVE_ENDIAN_H)
 check_include_files(sched.h HAVE_SCHED_H)
 check_include_files(linux/memfd.h HAVE_LINUX_MEMFD_H)
@@ -391,8 +383,6 @@ endif()
 add_cond(NET_IF_HEADERS HAVE_SYS_SOCKET_H sys/socket.h)
 list(APPEND NET_IF_HEADERS net/if.h)
 check_include_files("${NET_IF_HEADERS}" HAVE_NET_IF_H)
-
-endif()
 
 find_file(HAVE_DEV_PTMX NAMES /dev/ptmx PATHS / NO_DEFAULT_PATH)
 find_file(HAVE_DEV_PTC  NAMES /dev/ptc  PATHS / NO_DEFAULT_PATH)
@@ -420,9 +410,7 @@ endif()
 find_library(HAVE_LIBNCURSES ncurses)
 find_library(HAVE_LIBNSL nsl)
 find_library(HAVE_LIBREADLINE readline)
-if(IS_PY3)
 find_library(HAVE_LIBSENDFILE sendfile)
-endif()
 find_library(HAVE_LIBTERMCAP termcap)
 
 set(LIBUTIL_LIBRARIES )
@@ -466,7 +454,6 @@ if(WITH_THREAD OR PY_VERSION VERSION_GREATER_EQUAL "3.7")
   endif()
 endif()
 
-if(IS_PY3)
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_lib_crypto_RAND_egd.c)
 file(WRITE ${check_src} "/* Override any GCC internal prototype to avoid an error.
   Use char because int might match the return type of a GCC
@@ -486,7 +473,6 @@ python_platform_test(
   DIRECT
   )
 cmake_pop_check_state()
-endif()
 
 set_required_def(_POSIX_THREADS 1)    # Define on Linux as it is required for threading
 set_required_def(_POSIX_SOURCE 1)     # Define on Linux in order for 'stat' and other things to work.
@@ -766,7 +752,6 @@ add_cond(CFG_HEADERS HAVE_UTIL_H util.h)
 add_cond(CFG_HEADERS HAVE_UNISTD_H unistd.h)
 add_cond(CFG_HEADERS HAVE_UTIME_H utime.h)
 add_cond(CFG_HEADERS HAVE_WCHAR_H wchar.h)
-if(IS_PY3)
 add_cond(CFG_HEADERS HAVE_DIRENT_H dirent.h)
 add_cond(CFG_HEADERS HAVE_ENDIAN_H endian.h)
 add_cond(CFG_HEADERS HAVE_LINUX_MEMFD_H linux/memfd.h)
@@ -779,7 +764,6 @@ add_cond(CFG_HEADERS HAVE_SYS_MEMFD_H sys/memfd.h)
 add_cond(CFG_HEADERS HAVE_SYS_RESOURCE_H sys/resource.h)
 add_cond(CFG_HEADERS HAVE_SYS_SENDFILE_H sys/sendfile.h)
 add_cond(CFG_HEADERS HAVE_SYS_TIME_H sys/time.h)
-endif()
 
 if(HAVE_PTY_H)
   set(CFG_HEADERS ${CFG_HEADERS} pty.h utmp.h)
@@ -800,9 +784,7 @@ check_symbol_exists(ctermid      "${CFG_HEADERS}" HAVE_CTERMID)
 check_symbol_exists(ctermid_r    "${CFG_HEADERS}" HAVE_CTERMID_R)
 check_symbol_exists(dup2         "${CFG_HEADERS}" HAVE_DUP2)
 check_symbol_exists(epoll_create "${CFG_HEADERS}" HAVE_EPOLL)
-if(IS_PY3)
 check_symbol_exists(epoll_create1 "${CFG_HEADERS}" HAVE_EPOLL_CREATE1)
-endif()
 check_symbol_exists(execv        "${CFG_HEADERS}" HAVE_EXECV)
 check_symbol_exists(fchdir       "${CFG_HEADERS}" HAVE_FCHDIR)
 check_symbol_exists(fchmod       "${CFG_HEADERS}" HAVE_FCHMOD)
@@ -921,7 +903,6 @@ check_symbol_exists(waitpid      "${CFG_HEADERS}" HAVE_WAITPID)
 check_symbol_exists(wcscoll      "${CFG_HEADERS}" HAVE_WCSCOLL)
 check_symbol_exists(_getpty      "${CFG_HEADERS}" HAVE__GETPTY)
 
-if(IS_PY3)
 check_symbol_exists(accept4      "${CFG_HEADERS}" HAVE_ACCEPT4)
 check_symbol_exists(copy_file_range "${CFG_HEADERS}" HAVE_COPY_FILE_RANGE)
 check_symbol_exists(dup3         "${CFG_HEADERS}" HAVE_DUP3)
@@ -1005,7 +986,6 @@ check_symbol_exists(wcsftime               "${CFG_HEADERS}" HAVE_WCSFTIME)
 check_symbol_exists(wcsxfrm                "${CFG_HEADERS}" HAVE_WCSXFRM)
 check_symbol_exists(wmemcmp                "${CFG_HEADERS}" HAVE_WMEMCMP)
 check_symbol_exists(writev                 "${CFG_HEADERS}" HAVE_WRITEV)
-endif()
 
 check_struct_has_member("struct stat" st_mtim.tv_nsec "${CFG_HEADERS}" HAVE_STAT_TV_NSEC)
 check_struct_has_member("struct stat" st_mtimespec.tv_nsec "${CFG_HEADERS}"    HAVE_STAT_TV_NSEC2)
@@ -1017,12 +997,10 @@ check_struct_has_member("struct stat" st_flags   "${CFG_HEADERS}"    HAVE_STRUCT
 check_struct_has_member("struct stat" st_gen     "${CFG_HEADERS}"    HAVE_STRUCT_STAT_ST_GEN)
 check_struct_has_member("struct stat" st_rdev    "${CFG_HEADERS}"    HAVE_STRUCT_STAT_ST_RDEV)
 
-if(IS_PY3)
 check_struct_has_member("struct passwd" pw_gecos  "${CFG_HEADERS}" HAVE_STRUCT_PASSWD_PW_GECOS)
 check_struct_has_member("struct passwd" pw_passwd "${CFG_HEADERS}" HAVE_STRUCT_PASSWD_PW_PASSWD)
 
 check_struct_has_member("struct siginfo_t" si_band "${CFG_HEADERS}" HAVE_SIGINFO_T_SI_BAND)
-endif()
 
 #######################################################################
 #
@@ -1052,8 +1030,6 @@ endif()
 #
 #######################################################################
 
-if(IS_PY3)
-
 # Check for x64 gcc inline assembler
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/have_gcc_asm_for_x64.c)
 file(WRITE ${check_src} "int main () {
@@ -1066,8 +1042,6 @@ python_platform_test(
   ${check_src}
   DIRECT
   )
-
-endif()
 
 #######################################################################
 #
@@ -1296,8 +1270,6 @@ int main(void) {
   exit(0);
 }" HAVE_MMAP_DEV_ZERO)
 
-if(IS_PY3)
-
 # Check whether we can use gcc inline assembler to get and set mc68881 fpcr
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/have_gcc_asm_for_mc68881.c)
 file(WRITE ${check_src} "int main() {
@@ -1312,9 +1284,6 @@ python_platform_test(
   ${check_src}
   DIRECT
   )
-
-endif()
-
 
 # Check for x87-style double rounding
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_x87_double_rounding.c)
@@ -1433,7 +1402,6 @@ python_platform_test_run(
   DIRECT
   )
 
-if(IS_PY3)
 # Check whether log1p drops the sign of negative zero
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_log1p_drops_zero_sign.c)
 file(WRITE ${check_src} "#include <math.h>
@@ -1452,14 +1420,11 @@ python_platform_test_run(
   ${check_src}
   INVERT
   )
-endif()
 
 set(_funcs acosh asinh atanh copysign erf erfc expm1 finite gamma
   hypot lgamma log1p round tgamma
+  log2
   )
-if(IS_PY3)
-  list(APPEND _funcs log2)
-endif()
 foreach(func ${_funcs})
   string(TOUPPER ${func} _func_upper)
   check_function_exists(${func} HAVE_${_func_upper})
@@ -1507,8 +1472,6 @@ if(GETTIMEOFDAY_WITH_TZ)
 else()
   set(GETTIMEOFDAY_NO_TZ 1)
 endif()
-
-if(IS_PY3)
 
 if(APPLE)
   cmake_push_check_state()
@@ -1641,8 +1604,6 @@ if(NOT HAVE_CLOCK_SETTIME)
   if(HAVE_CLOCK_SETTIME)
     set(TIMEMODULE_LIB rt)
   endif()
-endif()
-
 endif()
 
 #######################################################################
@@ -2097,9 +2058,7 @@ check_type_size("uint64_t" HAVE_UINT64_T)
 check_type_size("int64_t" HAVE_INT64_T)
 check_type_size("uint32_t" HAVE_UINT32_T)
 check_type_size("int32_t" HAVE_INT32_T)
-if(IS_PY3)
 check_type_size("__uint128_t" HAVE_GCC_UINT128_T)
-endif()
 unset(CMAKE_EXTRA_INCLUDE_FILES)
 
 set(CMAKE_EXTRA_INCLUDE_FILES "sys/socket.h")
@@ -2186,8 +2145,6 @@ if(HAVE_C_CHAR_UNSIGNED AND NOT CMAKE_C_COMPILER_ID MATCHES "^GNU$")
   set(__CHAR_UNSIGNED__ 1)
 endif()
 
-if(IS_PY3)
-
 # Check if the dirent structure of a d_type field and DT_UNKNOWN is defined
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/have_dirent_d_type.c)
 file(WRITE ${check_src} "#include <dirent.h>
@@ -2242,8 +2199,6 @@ python_platform_test(
   DIRECT
   )
 
-endif()
-
 #######################################################################
 #
 # tests for bugs and other stuff
@@ -2254,7 +2209,6 @@ check_c_source_compiles("#include <unistd.h>\n int main() {getpgrp(0);}" GETPGRP
 
 check_c_source_compiles("#include <unistd.h>\n int main() {setpgrp(0, 0);}" SETPGRP_HAVE_ARG)
 
-if(IS_PY3)
 # Check for inline
 set(USE_INLINE 0)
 foreach(inline_type inline __inline__ __inline)
@@ -2301,7 +2255,6 @@ python_platform_test(
   DIRECT
   )
 cmake_pop_check_state()
-endif()
 
 check_c_source_runs("#include <unistd.h>\n int main() {
         int val1 = nice(1);
@@ -2414,8 +2367,6 @@ if(CMAKE_SYSTEM MATCHES AIX)
   set(HAVE_BROKEN_PIPE_BUF 1)
 endif()
 
-if(IS_PY3)
-
 # Define if aligned memory access is required
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/aligned_required.c)
 file(WRITE ${check_src} "int main()
@@ -2473,8 +2424,6 @@ if(HAVE_PTHREAD_H)
   endif()
 endif()
 
-endif(IS_PY3)
-
 # Check whether the compiler supports computed gotos
 set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_computed_gotos.c)
 file(WRITE ${check_src} "int main(int argc, char **argv)
@@ -2494,8 +2443,6 @@ python_platform_test_run(
   ${check_src}
   DIRECT
   )
-
-if(IS_PY3)
 
 # Availability of -O2
 cmake_push_check_state()
@@ -2592,8 +2539,6 @@ python_platform_test(
   ${check_src}
   DIRECT
   )
-
-endif(IS_PY3)
 
 if(HAVE_LONG_LONG)
   # Checking for %lld and %llu printf() format support
@@ -2786,7 +2731,6 @@ endif()
 
 ############################################
 
-if(IS_PY3)
 # Check for CAN_RAW_FD_FRAMES
 check_c_source_compiles("#include <linux/can/raw.h>\n int main () { int can_raw_fd_frames = CAN_RAW_FD_FRAMES; }" HAVE_LINUX_CAN_RAW_FD_FRAMES)
 
@@ -2811,8 +2755,6 @@ endif()
 # todo
 set(PTHREAD_SYSTEM_SCHED_SUPPORTED 1)
 set(HAVE_DEVICE_MACROS ${HAVE_MAKEDEV})
-
-endif()
 
 # setup the python platform
 set(PY_PLATFORM generic)

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -3,13 +3,6 @@ if(WIN32)
     set(WIN32_BUILTIN BUILTIN)
 endif()
 
-set(PY3_BUILTIN )
-set(PY3_ALWAYS_BUILTIN )
-if(IS_PY3)
-    set(PY3_BUILTIN BUILTIN)
-    set(PY3_ALWAYS_BUILTIN ALWAYS_BUILTIN)
-endif()
-
 add_python_extension(array ${WIN32_BUILTIN} SOURCES arraymodule.c)
 add_python_extension(audioop ${WIN32_BUILTIN} REQUIRES HAVE_LIBM SOURCES audioop.c LIBRARIES ${M_LIBRARIES})
 add_python_extension(_bisect ${WIN32_BUILTIN} SOURCES _bisectmodule.c)
@@ -20,7 +13,7 @@ add_python_extension(_codecs_iso2022 ${WIN32_BUILTIN} SOURCES cjkcodecs/_codecs_
 add_python_extension(_codecs_jp ${WIN32_BUILTIN} SOURCES cjkcodecs/_codecs_jp.c)
 add_python_extension(_codecs_kr ${WIN32_BUILTIN} SOURCES cjkcodecs/_codecs_kr.c)
 add_python_extension(_codecs_tw ${WIN32_BUILTIN} SOURCES cjkcodecs/_codecs_tw.c)
-add_python_extension(_collections ${WIN32_BUILTIN} ${PY3_BUILTIN} SOURCES _collectionsmodule.c) # Container types
+add_python_extension(_collections ${WIN32_BUILTIN} BUILTIN SOURCES _collectionsmodule.c) # Container types
 set(crypt2_NAME crypt)
 set(crypt2_SOURCES cryptmodule.c)
 set(crypt3_NAME _crypt)
@@ -41,7 +34,7 @@ add_python_extension(${datetime${PY_VERSION_MAJOR}_NAME} ${WIN32_BUILTIN} REQUIR
 #if(ENABLE_DATETIME AND CMAKE_C_COMPILER_ID MATCHES GNU)
 #    set_property(SOURCE ${SRC_DIR}/Modules/datetimemodule.c PROPERTY COMPILE_FLAGS -Wno-unused-value)
 #endif()
-add_python_extension(_functools ${WIN32_BUILTIN} ${PY3_BUILTIN} SOURCES _functoolsmodule.c DEFINITIONS Py_BUILD_CORE) # Tools for working with functions and callable objects
+add_python_extension(_functools ${WIN32_BUILTIN} BUILTIN SOURCES _functoolsmodule.c DEFINITIONS Py_BUILD_CORE) # Tools for working with functions and callable objects
 add_python_extension(_heapq ${WIN32_BUILTIN} SOURCES _heapqmodule.c)
 
 set(_io_SOURCES
@@ -58,11 +51,11 @@ if(WIN32 AND EXISTS ${SRC_DIR}/Modules/_io/winconsoleio.c)
         ${SRC_DIR}/Modules/_io/winconsoleio.c
         )
 endif()
-add_python_extension(_io ${WIN32_BUILTIN} ${PY3_ALWAYS_BUILTIN} SOURCES ${_io_SOURCES} DEFINITIONS Py_BUILD_CORE)
+add_python_extension(_io ${WIN32_BUILTIN} ALWAYS_BUILTIN SOURCES ${_io_SOURCES} DEFINITIONS Py_BUILD_CORE)
 
-add_python_extension(itertools ${WIN32_BUILTIN} ${PY3_BUILTIN} SOURCES itertoolsmodule.c) # Functions creating iterators for efficient looping
+add_python_extension(itertools ${WIN32_BUILTIN} BUILTIN SOURCES itertoolsmodule.c) # Functions creating iterators for efficient looping
 add_python_extension(_json ${WIN32_BUILTIN} SOURCES _json.c)
-add_python_extension(_locale ${WIN32_BUILTIN} ${PY3_BUILTIN} SOURCES _localemodule.c) # access to ISO C locale support
+add_python_extension(_locale ${WIN32_BUILTIN} BUILTIN SOURCES _localemodule.c) # access to ISO C locale support
 add_python_extension(_lsprof ${WIN32_BUILTIN} SOURCES _lsprof.c rotatingtree.c)
 add_python_extension(math ${WIN32_BUILTIN} REQUIRES HAVE_LIBM SOURCES _math.c mathmodule.c LIBRARIES ${M_LIBRARIES})
 add_python_extension(mmap ${WIN32_BUILTIN} SOURCES mmapmodule.c)
@@ -84,32 +77,32 @@ set(time_SOURCES timemodule.c)
 if(PY_VERSION VERSION_EQUAL "3.2")
   list(APPEND datetime${PY_VERSION_MAJOR}_SOURCES _time.c)
 endif()
-add_python_extension(time ${WIN32_BUILTIN} ${PY3_BUILTIN} REQUIRES HAVE_LIBM SOURCES ${time_SOURCES} DEFINITIONS Py_BUILD_CORE LIBRARIES ${M_LIBRARIES} ${TIMEMODULE_LIB})
+add_python_extension(time ${WIN32_BUILTIN} BUILTIN REQUIRES HAVE_LIBM SOURCES ${time_SOURCES} DEFINITIONS Py_BUILD_CORE LIBRARIES ${M_LIBRARIES} ${TIMEMODULE_LIB})
 add_python_extension(unicodedata SOURCES unicodedata.c)
 
 # Python3
-add_python_extension(atexit BUILTIN REQUIRES IS_PY3 SOURCES atexitmodule.c) # Register functions to be run at interpreter-shutdown
+add_python_extension(atexit BUILTIN REQUIRES SOURCES atexitmodule.c) # Register functions to be run at interpreter-shutdown
 add_python_extension(_codecs BUILTIN SOURCES _codecsmodule.c) # access to the builtin codecs and codec registry
-add_python_extension(faulthandler ALWAYS_BUILTIN REQUIRES IS_PY3 SOURCES faulthandler.c)
-add_python_extension(_opcode ${WIN32_BUILTIN} REQUIRES IS_PY3 SOURCES _opcode.c)
-add_python_extension(_operator BUILTIN REQUIRES IS_PY3 SOURCES _operator.c)
-add_python_extension(_pickle ${WIN32_BUILTIN} REQUIRES IS_PY3 SOURCES _pickle.c)
+add_python_extension(faulthandler ALWAYS_BUILTIN REQUIRES SOURCES faulthandler.c)
+add_python_extension(_opcode ${WIN32_BUILTIN} REQUIRES SOURCES _opcode.c)
+add_python_extension(_operator BUILTIN REQUIRES SOURCES _operator.c)
+add_python_extension(_pickle ${WIN32_BUILTIN} REQUIRES SOURCES _pickle.c)
 add_python_extension(_sre BUILTIN SOURCES _sre.c) # Fredrik Lundh's new regular expressions
-add_python_extension(_stat BUILTIN REQUIRES IS_PY3 SOURCES _stat.c) # stat.h interface
+add_python_extension(_stat BUILTIN REQUIRES SOURCES _stat.c) # stat.h interface
 add_python_extension(_symtable BUILTIN SOURCES symtablemodule.c)
 # Python PEP-3118 (buffer protocol) test module
-add_python_extension(_testbuffer REQUIRES IS_PY3 SOURCES _testbuffer.c)
+add_python_extension(_testbuffer REQUIRES SOURCES _testbuffer.c)
 # Test loading multiple modules from one compiled file (http://bugs.python.org/issue16421)
-add_python_extension(_testimportmultiple REQUIRES IS_PY3 SOURCES _testimportmultiple.c)
+add_python_extension(_testimportmultiple REQUIRES SOURCES _testimportmultiple.c)
 # Test multi-phase extension module init (PEP 489)
-add_python_extension(_testmultiphase REQUIRES IS_PY3 SOURCES _testmultiphase.c)
+add_python_extension(_testmultiphase REQUIRES SOURCES _testmultiphase.c)
 # debug tool to trace memory blocks allocated by Python
-add_python_extension(_tracemalloc ALWAYS_BUILTIN REQUIRES IS_PY3
+add_python_extension(_tracemalloc ALWAYS_BUILTIN REQUIRES
     SOURCES ${SRC_DIR}/$<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.9>,Python,Modules>/hashtable.c _tracemalloc.c
 )
 add_python_extension(_weakref ALWAYS_BUILTIN SOURCES _weakref.c)
 math(EXPR _limited_api_version "${PY_VERSION_MAJOR} * 100 + ${PY_VERSION_MINOR}")
-add_python_extension(xxlimited REQUIRES IS_PY3 BUILD_TESTING
+add_python_extension(xxlimited REQUIRES BUILD_TESTING
     SOURCES xxlimited.c
     DEFINITIONS Py_LIMITED_API=0x${_limited_api_version}0000
     NO_INSTALL
@@ -189,7 +182,7 @@ add_python_extension(termios REQUIRES UNIX SOURCES termios.c)
 
 # Python3: UNIX-only extensions
 add_python_extension(errno BUILTIN UNIX SOURCES errnomodule.c)
-add_python_extension(_posixsubprocess REQUIRES IS_PY3 UNIX SOURCES _posixsubprocess.c)
+add_python_extension(_posixsubprocess REQUIRES UNIX SOURCES _posixsubprocess.c)
 
 # MacOSX-only extensions
 set(_scproxy2_SOURCES ${SRC_DIR}/Mac/Modules/_scproxy.c)
@@ -227,18 +220,18 @@ add_python_extension(${winreg${PY_VERSION_MAJOR}_NAME} REQUIRES WIN32 BUILTIN SO
 
 # Python3: Windows-only extensions
 add_python_extension(_overlapped
-    REQUIRES WIN32 IS_PY3
+    REQUIRES WIN32
     SOURCES ${SRC_DIR}/Modules/overlapped.c
     LIBRARIES ws2_32 $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.9>:pathcch>
 )
-add_python_extension(_winapi REQUIRES WIN32 IS_PY3 BUILTIN SOURCES ${SRC_DIR}/Modules/_winapi.c)
+add_python_extension(_winapi REQUIRES WIN32 BUILTIN SOURCES ${SRC_DIR}/Modules/_winapi.c)
 
 set(HAS_DISTUTILS_FINDVS_MODULE_SRC 0)
 set(module_src ${SRC_DIR}/PC/_findvs.cpp)
 if(EXISTS ${module_src})
   set(HAS_DISTUTILS_FINDVS_MODULE_SRC 1)
 endif()
-add_python_extension(_distutils_findvs REQUIRES WIN32 IS_PY3 HAS_DISTUTILS_FINDVS_MODULE_SRC SOURCES ${module_src})
+add_python_extension(_distutils_findvs REQUIRES WIN32 HAS_DISTUTILS_FINDVS_MODULE_SRC SOURCES ${module_src})
 
 # Multiprocessing is different on unix and windows
 if(UNIX)
@@ -422,8 +415,6 @@ endif()
 endif()
 
 # Python3: _decimal
-if(IS_PY3)
-
 set(libmpdec_config_x64          CONFIG_64 ASM)
 set(libmpdec_config_uint128      CONFIG_64 ANSI HAVE_UINT128_T)
 set(libmpdec_config_ansi64       CONFIG_64 ANSI)
@@ -550,8 +541,6 @@ if(_decimal_compile_flags AND ENABLE_DECIMAL AND TARGET extension_decimal AND NO
     set_target_properties(extension_decimal PROPERTIES COMPILE_FLAGS ${_decimal_compile_flags})
 endif()
 
-endif()
-
 # Build expat using the system expat if it's installed, otherwise use the
 # builtin version.
 if(EXPAT_LIBRARIES AND EXPAT_INCLUDE_DIRS)
@@ -653,11 +642,7 @@ add_python_extension(_curses
 )
 set(dbm2_SOURCES dbmmodule.c)
 set(dbm3_SOURCES _dbmmodule.c)
-if(IS_PY3)
   set(dbm_name _dbm)
-else()
-  set(dbm_name dbm)
-endif()
 add_python_extension(${dbm_name}
     REQUIRES NDBM_TAG GDBM_LIBRARY GDBM_COMPAT_LIBRARY
     SOURCES ${dbm${PY_VERSION_MAJOR}_SOURCES}
@@ -667,11 +652,7 @@ add_python_extension(${dbm_name}
 )
 set(gdbm2_SOURCES gdbmmodule.c)
 set(gdbm3_SOURCES _gdbmmodule.c)
-if(IS_PY3)
   set(gdbm_name _gdbm)
-else()
-  set(gdbm_name gdbm)
-endif()
 add_python_extension(${gdbm_name}
     REQUIRES GDBM_INCLUDE_PATH GDBM_LIBRARY GDBM_COMPAT_LIBRARY
     SOURCES ${gdbm${PY_VERSION_MAJOR}_SOURCES}
@@ -690,7 +671,7 @@ if(ENABLE_HASHLIB AND CMAKE_C_COMPILER_ID MATCHES GNU)
 endif()
 # lzma module was introduced in Python 3.3
 set(is_py33_or_greater 0)
-if(IS_PY3 AND PY_VERSION_MINOR VERSION_GREATER 2)
+if(PY_VERSION_MINOR VERSION_GREATER 2)
   set(is_py33_or_greater 1)
 endif()
 add_python_extension(_lzma

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -546,7 +546,7 @@ add_python_extension(_decimal
     ${_decimal_LIBRARIES}
     ${_decimal_INCLUDEDIRS}
 )
-if(_decimal_compile_flags AND ENABLE_DECIMAL AND NOT BUILTIN_DECIMAL)
+if(_decimal_compile_flags AND ENABLE_DECIMAL AND TARGET extension_decimal AND NOT BUILTIN_DECIMAL)
     set_target_properties(extension_decimal PROPERTIES COMPILE_FLAGS ${_decimal_compile_flags})
 endif()
 
@@ -780,7 +780,7 @@ else()
     )
 endif()
 
-if(USE_LIBEDIT AND ENABLE_READLINE AND NOT BUILTIN_READLINE)
+if(USE_LIBEDIT AND ENABLE_READLINE AND TARGET extension_readline AND NOT BUILTIN_READLINE)
     set_target_properties(extension_readline PROPERTIES
         COMPILE_DEFINITIONS "USE_LIBEDIT")
 endif()

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -54,9 +54,7 @@ elseif(WIN32)
     endif()
 
     set(_wide_char_modifier)
-    if(IS_PY3)
         set(_wide_char_modifier "L")
-    endif()
 
     set_property(
         SOURCE ${SRC_DIR}/PC/getpathp.c
@@ -193,13 +191,11 @@ if(UNIX AND HAVE_DLOPEN)
     list(APPEND DYNLOAD_SOURCES
         ${SRC_DIR}/Python/dynload_shlib.c
     )
-    if(IS_PY3)
     set_property(
         SOURCE ${SRC_DIR}/Python/dynload_shlib.c
         PROPERTY COMPILE_DEFINITIONS
             SOABI="${SOABI}"
         )
-    endif()
 elseif(WIN32)
     list(APPEND DYNLOAD_SOURCES
         ${SRC_DIR}/PC/dl_nt.c
@@ -323,13 +319,11 @@ if(UNIX OR MINGW)
         PROPERTY COMPILE_DEFINITIONS
             PLATFORM="${PY_PLATFORM}"
     )
-    if(IS_PY3)
     set_property(
         SOURCE ${SRC_DIR}/Python/sysmodule.c
         PROPERTY COMPILE_DEFINITIONS
             ABIFLAGS="${ABIFLAGS}"
         )
-    endif()
 endif()
 
 list(APPEND MODULE_SOURCES
@@ -441,7 +435,7 @@ endif()
 if(UNIX)
     list(APPEND LIBPYTHON_TARGET_LIBRARIES ${LIBUTIL_LIBRARIES} ${M_LIBRARIES})
 endif()
-if(WIN32 AND IS_PY3)
+if(WIN32)
     list(APPEND LIBPYTHON_TARGET_LIBRARIES ws2_32) # Required by signalmodule
     if(PY_VERSION VERSION_GREATER_EQUAL "3.5")
         list(APPEND LIBPYTHON_TARGET_LIBRARIES version) # Required by sysmodule
@@ -455,7 +449,6 @@ if(WIN32 AND IS_PY3)
 endif()
 
 set(LIBPYTHON_FROZEN_SOURCES )
-if(IS_PY3)
 
 # Build _freeze_importlib executable
 add_executable(_freeze_importlib
@@ -511,8 +504,6 @@ endif()
 # This is a convenience target allowing to regenerate
 # the frozen sources.
 add_custom_target(freeze_modules DEPENDS ${LIBPYTHON_FROZEN_SOURCES})
-
-endif()
 
 if(PY_VERSION VERSION_LESS "3.8")
 # Build pgen executable
@@ -601,7 +592,7 @@ if(BUILD_LIBPYTHON_SHARED)
 
     set(targetname "libpython3-shared")
 
-    if(IS_PY3 AND MSVC)
+    if(MSVC)
         # XXX Add BuildPython3_dDef
 
         # Generate 'python3stub.def'
@@ -646,7 +637,7 @@ if(BUILD_LIBPYTHON_SHARED)
         target_link_libraries(${targetname} ${python3stub_lib})
     endif()
 
-    if(IS_PY3 AND UNIX AND NOT APPLE)
+    if(UNIX AND NOT APPLE)
         add_library(${targetname} SHARED ${PROJECT_SOURCE_DIR}/cmake/empty.c)
         set_target_properties(${targetname} PROPERTIES
             LINK_FLAGS "-Wl,--no-as-needed"


### PR DESCRIPTION
* Removes use of `IS_PY3` and replaces both `${PY3_BUILTIN}` and `${PY3_ALWAYS_BUILTIN}` respectively with `BUILTIN` and `ALWAYS_BUILTIN`.
* Fixes logic setting target properties: Attempt to set target properties only if target was effectively added. Checking if the `ENABLE_<upper_extension_name>` is set to ON only indicates that the extension was requested.