### PR TITLE
cmake: Fix warning reported when setting WITH_THREAD with Python < 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,7 +364,7 @@ if(PY_VERSION VERSION_LESS "3.7")
     option(WITH_THREAD "Compile in rudimentary thread support" ON)
 else()
     if(DEFINED WITH_THREAD)
-        message(AUTHOR_WARNING "WITH_THREAD option is *NOT* supported with Python < 3.7. Current version is ${PY_VERSION}")
+        message(AUTHOR_WARNING "WITH_THREAD option is *NOT* supported. Threading is always built-in with Python >= 3.7. Current version is ${PY_VERSION}")
     endif()
 endif()
 


### PR DESCRIPTION
Follow-up of 97631f2 ("Add support for building Python 3.7.x", 2022-01-05) Since threading is always built-in with Python >= 3.7, the warning message has been updated accordingly.