### PR TITLE
cmake: Remove setting of obsolete variables specific to Python 2

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -235,9 +235,6 @@ add_python_extension(_distutils_findvs REQUIRES WIN32 HAS_DISTUTILS_FINDVS_MODUL
 
 # Multiprocessing is different on unix and windows
 if(UNIX)
-    set(_multiprocessing2_SOURCES
-        _multiprocessing/socket_connection.c
-    )
     set(_multiprocessing3_SOURCES )
     if(HAVE_SEM_OPEN AND NOT POSIX_SEMAPHORES_NOT_ENABLED)
         list(APPEND _multiprocessing${PY_VERSION_MAJOR}_SOURCES
@@ -254,11 +251,6 @@ if(UNIX)
         REQUIRES ${_multiprocessing_REQUIRES}
     )
 elseif(WIN32)
-    set(_multiprocessing2_SOURCES
-        _multiprocessing/pipe_connection.c
-        _multiprocessing/socket_connection.c
-        _multiprocessing/win32_functions.c
-    )
     set(_multiprocessing3_SOURCES )
     add_python_extension(_multiprocessing
         SOURCES _multiprocessing/multiprocessing.c
@@ -616,7 +608,6 @@ add_python_extension(binascii
     LIBRARIES ${binascii_LIBRARIES}
     INCLUDEDIRS ${binascii_INCLUDEDIRS}
 )
-set(bz2_2_NAME bz2)
 set(bz2_3_NAME _bz2)
 add_python_extension(${bz2_${PY_VERSION_MAJOR}_NAME}
     REQUIRES BZIP2_LIBRARIES BZIP2_INCLUDE_DIR

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -97,20 +97,6 @@ else()
     )
 endif()
 
-set(OBJECT2_SOURCES
-    ${SRC_DIR}/Objects/bufferobject.c
-    ${SRC_DIR}/Objects/cobject.c
-    ${SRC_DIR}/Objects/intobject.c
-    ${SRC_DIR}/Objects/stringobject.c
-)
-if(MSVC)
-    if(EXISTS ${SRC_DIR}/PC/invalid_parameter_handler.c)
-        list(APPEND OBJECT2_SOURCES
-            ${SRC_DIR}/PC/invalid_parameter_handler.c
-        )
-    endif()
-endif()
-
 set(OBJECT3_SOURCES
     ${SRC_DIR}/Objects/accu.c
     ${SRC_DIR}/Objects/bytesobject.c
@@ -217,16 +203,6 @@ set(THREAD_SOURCES )
 if(WITH_THREAD OR PY_VERSION VERSION_GREATER_EQUAL "3.7")
     list(APPEND THREAD_SOURCES
         ${SRC_DIR}/Python/thread.c
-    )
-endif()
-
-set(PYTHON2_COMMON_SOURCES
-    ${SRC_DIR}/Python/formatter_string.c
-    ${SRC_DIR}/Python/pystrtod.c
-)
-if(WIN32)
-    list(APPEND PYTHON2_COMMON_SOURCES
-        ${SRC_DIR}/PC/import_nt.c
     )
 endif()
 
@@ -504,9 +480,6 @@ add_custom_target(freeze_modules DEPENDS ${LIBPYTHON_FROZEN_SOURCES})
 
 if(PY_VERSION VERSION_LESS "3.8")
 # Build pgen executable
-set(PGEN2_SOURCES
-    ${SRC_DIR}/Parser/parsetok.c
-)
 set(PGEN3_SOURCES
     ${SRC_DIR}/Python/dynamic_annotations.c
     ${SRC_DIR}/Parser/parsetok_pgen.c

--- a/cmake/python/CMakeLists.txt
+++ b/cmake/python/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(subdir_2  Modules)
 set(subdir_3  Programs)
 
 set(PYTHON_SOURCES


### PR DESCRIPTION
This commit removes setting of the following variables:
- `OBJECT2_SOURCES`
- `PYTHON2_COMMON_SOURCES`
- `PGEN2_SOURCES`
- `_multiprocessing2_SOURCES`
- `bz2_2_NAME`
- `subdir_2`

Follow-up of 6391889 ("cmake: Remove support for building CPython 2.7", 2025-04-28)