### PR TITLE
Pin GitHub Actions and add Dependabot workflow to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,23 +22,23 @@ jobs:
 
     name: python-${{ matrix.python-version }}-${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: 0
         path: src
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.13.1
+      uses: jwlawson/actions-setup-cmake@65b272e1213f99771fbba0c237e0b3312270e0c9 # v1.13.1
       with:
         cmake-version: 3.13.5
 
     - name: Setup ninja
-      uses: ashutoshvarma/setup-ninja@master
+      uses: ashutoshvarma/setup-ninja@66ad2db9ed7d211c065daeeb849e9c8c895773c9 # master
       with:
         version: 1.10.0
 
     - name: Download dashboard script
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         repository: 'python-cmake-buildsystem/python-cmake-buildsystem'
         ref: dashboard

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Makefile
 .*
 !.gitattributes
 !.circleci
+!.github/
 
 # Ignore all back-up files...
 *~


### PR DESCRIPTION
Summary:
* Add Dependabot workflow to update GitHub Actions
  - https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
  - https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions
* Pin GitHub actions to full length commit SHA
  - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Working toward addressing:
* #350