### PR TITLE
Attempt to fix support for python 3.0 to 3.5

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -1653,6 +1653,41 @@ python_platform_test(
 #ucs2
 set(HAVE_USABLE_WCHAR_T 0)
 
+if(PY_VERSION VERSION_LESS "3.3")
+  if(NOT DEFINED Py_UNICODE_SIZE)
+    if(HAVE_UCS4_TCL)
+      message(STATUS "Defaulting Py_UNICODE_SIZE to 4 because HAVE_UCS4_TCL is set")
+      set(Py_UNICODE_SIZE 4)
+    else()
+      # Py_UNICODE defaults to two-byte mode
+      set(Py_UNICODE_SIZE 2)
+    endif()
+  endif()
+
+  if("${Py_UNICODE_SIZE}" STREQUAL "${SIZEOF_WCHAR_T}")
+    set(PY_UNICODE_TYPE wchar_t)
+    set(HAVE_USABLE_WCHAR_T 1)
+    message(STATUS "Using wchar_t for unicode [Py_UNICODE_SIZE: ${Py_UNICODE_SIZE}]")
+  else()
+
+    if("${Py_UNICODE_SIZE}" STREQUAL "${SIZEOF_SHORT}")
+      set(PY_UNICODE_TYPE "unsigned short")
+      set(HAVE_USABLE_WCHAR_T 0)
+      message(STATUS "Using unsigned short for unicode [Py_UNICODE_SIZE: ${Py_UNICODE_SIZE}]")
+    else()
+
+      if("${Py_UNICODE_SIZE}" STREQUAL "${SIZEOF_LONG}")
+        set(PY_UNICODE_TYPE "unsigned long")
+        set(HAVE_USABLE_WCHAR_T 0)
+        message(STATUS "Using unsigned long for unicode [Py_UNICODE_SIZE: ${Py_UNICODE_SIZE}]")
+      else()
+        message(FATAL_ERROR "No usable unicode type found for [Py_UNICODE_SIZE: ${Py_UNICODE_SIZE}]
+  Set Py_UNICODE_SIZE to either ${SIZEOF_WCHAR_T}, ${SIZEOF_SHORT} or ${SIZEOF_LONG}")
+      endif()
+    endif()
+  endif()
+endif()
+
 if(PY_VERSION VERSION_GREATER_EQUAL "3.7")
 set(PY_COERCE_C_LOCALE ${WITH_C_LOCALE_COERCION})
 endif()

--- a/cmake/config-mingw/pyconfig.h
+++ b/cmake/config-mingw/pyconfig.h
@@ -377,6 +377,10 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Define if you want to use the GNU readline library */
 /* #define WITH_READLINE 1 */
 
+/* Define as the size of the unicode type. [Python 2.7 to 3.2] */
+/* This is enough for unicodeobject.h to do the "right thing" on Windows. */
+#define Py_UNICODE_SIZE 2
+
 /* Use Python's own small-block memory-allocator. */
 #define WITH_PYMALLOC 1
 

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1477,11 +1477,17 @@
 /* Cipher suite string for PY_SSL_DEFAULT_CIPHERS=0 [Python 3.7] */
 #cmakedefine PY_SSL_DEFAULT_CIPHER_STRING "@PY_SSL_DEFAULT_CIPHER_STRING@"
 
+/* Define as the integral type used for Unicode representation. [Python 2.7 to 3.2] */
+#cmakedefine PY_UNICODE_TYPE @PY_UNICODE_TYPE@
+
 /* Define if you want to build an interpreter with many run-time checks. */
 #cmakedefine Py_DEBUG 1
 
 /* Defined if Python is built as a shared library. */
 #cmakedefine Py_ENABLE_SHARED
+
+/* Define as the size of the unicode type. [Python 2.7 to 3.2] */
+#cmakedefine Py_UNICODE_SIZE @Py_UNICODE_SIZE@
 
 /* assume C89 semantics that RETSIGTYPE is always void */
 #define RETSIGTYPE void

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -8,6 +8,15 @@ set(IS_PY3_3_OR_GREATER 0)
 if(PY_VERSION VERSION_GREATER_EQUAL "3.3")
     set(IS_PY3_3_OR_GREATER 1)
 endif()
+set(IS_PY3_4_OR_GREATER 0)
+if(PY_VERSION VERSION_GREATER_EQUAL "3.4")
+    set(IS_PY3_4_OR_GREATER 1)
+endif()
+set(IS_PY3_5_OR_GREATER 0)
+if(PY_VERSION VERSION_GREATER_EQUAL "3.5")
+    set(IS_PY3_5_OR_GREATER 1)
+endif()
+
 add_python_extension(array ${WIN32_BUILTIN} SOURCES arraymodule.c)
 add_python_extension(audioop ${WIN32_BUILTIN} REQUIRES HAVE_LIBM SOURCES audioop.c LIBRARIES ${M_LIBRARIES})
 add_python_extension(_bisect ${WIN32_BUILTIN} SOURCES _bisectmodule.c)
@@ -21,6 +30,9 @@ add_python_extension(_codecs_tw ${WIN32_BUILTIN} SOURCES cjkcodecs/_codecs_tw.c)
 add_python_extension(_collections ${WIN32_BUILTIN} BUILTIN SOURCES _collectionsmodule.c) # Container types
 
 set(crypt_NAME _crypt)
+if(PY_VERSION VERSION_LESS 3.3)
+    set(crypt_NAME crypt)
+endif()
 add_python_extension(${crypt_NAME}
     REQUIRES
         HAVE_LIBCRYPT
@@ -124,11 +136,17 @@ add_python_extension(unicodedata SOURCES unicodedata.c)
 # Python3
 add_python_extension(atexit BUILTIN REQUIRES SOURCES atexitmodule.c) # Register functions to be run at interpreter-shutdown
 add_python_extension(_codecs BUILTIN SOURCES _codecsmodule.c) # access to the builtin codecs and codec registry
-add_python_extension(_operator BUILTIN REQUIRES SOURCES _operator.c)
+set(operator_NAME _operator)
+if(PY_VERSION VERSION_LESS 3.4)
+    set(operator_NAME operator)
+endif()
+add_python_extension(${operator_NAME} BUILTIN REQUIRES SOURCES ${operator_NAME}.c)
 add_python_extension(faulthandler ALWAYS_BUILTIN
+    REQUIRES IS_PY3_3_OR_GREATER
     SOURCES faulthandler.c
 )
 add_python_extension(_opcode ${WIN32_BUILTIN}
+    REQUIRES IS_PY3_4_OR_GREATER
     SOURCES _opcode.c
 )
 
@@ -142,6 +160,7 @@ add_python_extension(_sre BUILTIN
 
 # stat.h interface
 add_python_extension(_stat BUILTIN
+    REQUIRES IS_PY3_4_OR_GREATER
     SOURCES _stat.c
 )
 
@@ -149,19 +168,23 @@ add_python_extension(_symtable BUILTIN SOURCES symtablemodule.c)
 
 # Python PEP-3118 (buffer protocol) test module
 add_python_extension(_testbuffer
+    REQUIRES IS_PY3_3_OR_GREATER
     SOURCES _testbuffer.c
 )
 
 # Test loading multiple modules from one compiled file (http://bugs.python.org/issue16421)
 add_python_extension(_testimportmultiple
+    REQUIRES IS_PY3_4_OR_GREATER
     SOURCES _testimportmultiple.c
 )
 # Test multi-phase extension module init (PEP 489)
 add_python_extension(_testmultiphase
+    REQUIRES IS_PY3_5_OR_GREATER
     SOURCES _testmultiphase.c
 )
 # debug tool to trace memory blocks allocated by Python
 add_python_extension(_tracemalloc ALWAYS_BUILTIN
+    REQUIRES IS_PY3_4_OR_GREATER
     SOURCES
        ${SRC_DIR}/$<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.9>,Python,Modules>/hashtable.c
        _tracemalloc.c
@@ -610,6 +633,7 @@ if(ENABLE_DECIMAL)
     message(STATUS "extension_decimal: libmpdec_config [${libmpdec_config}]")
 endif()
 add_python_extension(_decimal
+    REQUIRES IS_PY3_3_OR_GREATER
     SOURCES
         _decimal/_decimal.c
         _decimal/docstrings.h
@@ -736,6 +760,7 @@ add_python_extension(_gdbm
 )
 add_python_extension(_hashlib
     REQUIRES OPENSSL_INCLUDE_DIR OPENSSL_LIBRARIES
+      IS_PY3_5_OR_GREATER
     SOURCES _hashopenssl.c
     LIBRARIES ${OPENSSL_LIBRARIES}
     INCLUDEDIRS ${OPENSSL_INCLUDE_DIR}
@@ -790,6 +815,7 @@ if(WIN32)
 endif()
 add_python_extension(_ssl
     REQUIRES OPENSSL_INCLUDE_DIR OPENSSL_LIBRARIES
+      IS_PY3_5_OR_GREATER
     SOURCES ${_ssl_SOURCES}
     LIBRARIES ${_ssl_LIBRARIES}
     INCLUDEDIRS ${OPENSSL_INCLUDE_DIR}

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -95,8 +95,6 @@ set(PARSER_COMMON_SOURCES # Equivalent to POBJS in Makefile.pre
 set(OBJECT_COMMON_SOURCES # Equivalent to OBJECT_OBJS in Makefile.pre
     ${SRC_DIR}/Objects/accu.c
     ${SRC_DIR}/Objects/bytesobject.c
-    ${SRC_DIR}/Objects/namespaceobject.c
-    ${SRC_DIR}/Objects/odictobject.c
     $<$<C_COMPILER_ID:MSVC>:${SRC_DIR}/PC/invalid_parameter_handler.c>
     ${SRC_DIR}/Objects/abstract.c
     ${SRC_DIR}/Objects/boolobject.c
@@ -133,6 +131,12 @@ set(OBJECT_COMMON_SOURCES # Equivalent to OBJECT_OBJS in Makefile.pre
     ${SRC_DIR}/Objects/unicodectype.c
     ${SRC_DIR}/Objects/unicodeobject.c
     ${SRC_DIR}/Objects/weakrefobject.c
+
+    # Introduced in Python 3.3
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.3>:${SRC_DIR}/Objects/namespaceobject.c>
+
+    # Introduced in Python 3.5
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>:${SRC_DIR}/Objects/odictobject.c>
 
     # Introduced in Python 3.7
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.7>:${SRC_DIR}/Objects/call.c>
@@ -184,9 +188,6 @@ set(PYTHON_COMMON_SOURCES
     ${DYNLOAD_SOURCES}
     ${SRC_DIR}/Python/dynamic_annotations.c
     ${SRC_DIR}/Python/fileutils.c
-    ${SRC_DIR}/Python/pyhash.c
-    ${SRC_DIR}/Python/pylifecycle.c
-    ${SRC_DIR}/Python/pystrhex.c
     ${SRC_DIR}/Python/pystrtod.c
     ${SRC_DIR}/Python/pytime.c
     ${SRC_DIR}/Python/asdl.c
@@ -226,6 +227,13 @@ set(PYTHON_COMMON_SOURCES
     ${SRC_DIR}/Python/sysmodule.c
     ${SRC_DIR}/Python/traceback.c
     ${SRC_DIR}/Python/_warnings.c
+
+    # Introduced in Python 3.4
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.4>:${SRC_DIR}/Python/pyhash.c>
+
+    # Introduced in Python 3.5
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>:${SRC_DIR}/Python/pylifecycle.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>:${SRC_DIR}/Python/pystrhex.c>
 
     # Removed in Python 3.7
     $<$<VERSION_LESS:${PY_VERSION},3.7>:${SRC_DIR}/Python/random.c>
@@ -383,7 +391,7 @@ set(LIBPYTHON_FROZEN_SOURCES )
 
 # Build _freeze_importlib executable
 add_executable(_freeze_importlib
-  ${SRC_DIR}/Programs/_freeze_importlib.c
+  $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.3>:${SRC_DIR}/$<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>,Programs,Modules>/_freeze_importlib.c>
   ${LIBPYTHON_OMIT_FROZEN_SOURCES}
   )
 target_link_libraries(_freeze_importlib ${LIBPYTHON_TARGET_LIBRARIES})
@@ -437,13 +445,20 @@ if(PY_VERSION VERSION_LESS "3.8")
 add_executable(pgen
     ${PARSER_COMMON_SOURCES}
     ${SRC_DIR}/Python/dynamic_annotations.c
-    ${SRC_DIR}/Parser/parsetok_pgen.c
     ${SRC_DIR}/Objects/obmalloc.c
     ${SRC_DIR}/Python/mysnprintf.c
     ${SRC_DIR}/Python/pyctype.c
     ${SRC_DIR}/Parser/tokenizer_pgen.c
     ${SRC_DIR}/Parser/printgrammar.c
     ${SRC_DIR}/Parser/pgenmain.c
+
+    # Removed in Python 3.10 but excluded starting with Python 3.3 when the new parser
+    # was introduced.
+    # See cpython/cpython@1ed83adb0e9 ("bpo-40939: Remove the old parser (GH-20768)", 2020-06-11)
+    $<$<VERSION_LESS:${PY_VERSION},3.3>:${SRC_DIR}/Parser/parsetok.c>
+
+    # Introduced in Python 3.3
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.3>:${SRC_DIR}/Parser/parsetok_pgen.c>
 )
 if(builtin_compile_definitions_without_py_limited_api)
   target_compile_definitions(pgen PUBLIC ${builtin_compile_definitions_without_py_limited_api})

--- a/cmake/python/CMakeLists.txt
+++ b/cmake/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(PYTHON_SOURCES
-    ${SRC_DIR}/Programs/python.c
+    ${SRC_DIR}/$<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>,Programs,Modules>/python.c
 )
 
 add_executable(python ${PYTHON_SOURCES})


### PR DESCRIPTION
* Re-introduce unicode defines to support to support Python 3.0 to 3.2: Partially reverts b979b95 ("cmake: Remove obsolete defines from pyconfig.h and pyconfig.h.in", 2025-04-29) and 6391889 ("cmake: Remove support for building CPython 2.7", 2025-04-28).
* Attempt to fix build for Python 3.0 to 3.5: In an attempt to workaround issue to link against newer openssl library, extensions `_ssl` and `_hashlib` have been excluded for Python < 3.5