### PR TITLE
ci: Streamline branch protection setup adding "pass" job to GitHub workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,3 +59,16 @@ jobs:
         PY_VERSION: ${{ matrix.python-version }}
         CC: ${{ matrix.c-compiler }}
         CXX: ${{ matrix.cxx-compiler }}
+
+  pass: # This job does nothing and is only used for the branch protection
+    if: always()
+    needs:
+    - tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@223e4bb7a751b91f43eda76992bcfbf23b8b0302 # v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Adapted from similar changes introduced in the `scikit-build/scikit-build-core` project.

For more details, see https://github.com/re-actors/alls-green