### PR TITLE
cmake: Fix VERSION_EQUAL checks to compare only major.minor

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -81,7 +81,7 @@ add_python_extension(_datetime ${WIN32_BUILTIN}
     SOURCES
         _datetimemodule.c
         $<$<VERSION_LESS_EQUAL:${PY_VERSION},3.1>:timemodule.c>
-        $<$<VERSION_EQUAL:${PY_VERSION},3.2>:_time.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.2>:_time.c>
     LIBRARIES
         ${M_LIBRARIES}
 )
@@ -153,7 +153,7 @@ add_python_extension(time ${WIN32_BUILTIN} BUILTIN
         HAVE_LIBM
     SOURCES
         timemodule.c
-        $<$<VERSION_EQUAL:${PY_VERSION},3.2>:_time.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.2>:_time.c>
     DEFINITIONS
         Py_BUILD_CORE
     LIBRARIES


### PR DESCRIPTION
The existing use of VERSION_EQUAL assumed a patch version of `.0` (e.g. `3.2.0`), which breaks for any `3.2.x` release. Change the comparison to use only the major and minor components (e.g. `3.2`) so that all patch‐level variants are correctly recognized.

Fix regression originally introduced in the following commits:
* 7b6b8fa ("datetime, time: Fix build conditionally including _time.c or timemodule.c", 2022-01-18)
* 39e9d3d ("cmake: Simplify removing versioned variables", 2025-05-01)
* 8943355 ("cmake: Simplify extension build-system using genex to include _time.c", 2025-05-05)

Working toward addressing:
* #350

Follow-up of:
* https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/371
* https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/373