### PR TITLE
Add support for building Python 3.11.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,17 @@ jobs:
 workflows:
     build-and-test:
       jobs:
+        # 3.11.12
+        - build-test-python:
+            name: python-3.11.12-x64
+            python_version: 3.11.12
+            python_arch: x64
+
+        - build-test-python:
+            name: python-3.11.12-x86
+            python_version: 3.11.12
+            python_arch: x86
+
         # 3.10.17
         - build-test-python:
             name: python-3.10.17-x64
@@ -144,6 +155,13 @@ workflows:
 
     build-and-test-win:
       jobs:
+        # 3.11.12
+        - build-test-python-win:
+            name: python-3.11.12-win-x64
+            python_version: 3.11.12
+            python_arch: x64
+            generator: "Visual Studio 16 2019"
+
         # 3.10.17
         - build-test-python-win:
             name: python-3.10.17-win-x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [macos-latest]
-        python-version: [3.7.17, 3.8.20, 3.9.22, 3.10.17]
+        python-version: [3.7.17, 3.8.20, 3.9.22, 3.10.17, 3.11.12]
         include:
           - runs-on: macos-latest
             c-compiler: "clang"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20.6)
 
-set(PYTHON_VERSION "3.10.17" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.11.12" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)
@@ -297,6 +297,20 @@ set(_download_3.10.14_md5 "f67d78c8323a18fe6b945914c51a7aa6")
 set(_download_3.10.15_md5 "b6a2b570ea75ef55f50bfe79d778eb01")
 set(_download_3.10.16_md5 "2515d8571c6fdd7fc620aa9e1cc6d202")
 set(_download_3.10.17_md5 "763324aa2b396ee10a51bfa6c645d8e9")
+# 3.11.x
+set(_download_3.11.0_md5 "c5f77f1ea256dc5bdb0897eeb4d35bb0")
+set(_download_3.11.1_md5 "5c986b2865979b393aa50a31c65b64e8")
+set(_download_3.11.2_md5 "f6b5226ccba5ae1ca9376aaba0b0f673")
+set(_download_3.11.3_md5 "016ba65bc80411f9ec20c614ab385e81")
+set(_download_3.11.4_md5 "bf6ec50f2f3bfa6ffbdb385286f2c628")
+set(_download_3.11.5_md5 "b628f21aae5e2c3006a12380905bb640")
+set(_download_3.11.6_md5 "ed23dadb9f1b9fd2e4e7d78619685c79")
+set(_download_3.11.7_md5 "ef61f81ec82c490484219c7f0ec96783")
+set(_download_3.11.8_md5 "7fb0bfaa2f6aae4aadcdb51abe957825")
+set(_download_3.11.9_md5 "bfd4d3bfeac4216ce35d7a503bf02d5c")
+set(_download_3.11.10_md5 "35c36069a43dd57a7e9915deba0f864e")
+set(_download_3.11.11_md5 "9a5b43fcc06810b8ae924b0a080e6569")
+set(_download_3.11.12_md5 "b8bb496014f05f5be180fab74810f40b")
 
 set(_extracted_dir "Python-${PY_VERSION}")
 
@@ -543,10 +557,13 @@ include_directories(${INCLUDE_BUILD_DIR})
 include_directories(${INCLUDE_BUILD_DIR}/internal)
 include_directories(${PYCONFIG_BUILD_DIR})
 include_directories(${SRC_DIR}/Python)
+include_directories(${SRC_DIR}) # Introduced in Python 3.11 for "Python/frozen_modules/.h"
 
 # Set cflags used by all components
 if(CMAKE_C_COMPILER_ID MATCHES GNU)
-    if(PY_VERSION VERSION_GREATER_EQUAL "3.6")
+    if(PY_VERSION VERSION_GREATER_EQUAL "3.11")
+        append_if_absent(CMAKE_C_FLAGS "-std=c11")
+    elseif(PY_VERSION VERSION_GREATER_EQUAL "3.6")
         append_if_absent(CMAKE_C_FLAGS "-std=c99")
     endif()
     append_if_absent(CMAKE_C_FLAGS "-Wall")
@@ -784,7 +801,9 @@ file(MAKE_DIRECTORY "${EXTENSION_BUILD_DIR}")
 install(DIRECTORY DESTINATION ${EXTENSION_INSTALL_DIR})
 
 if(BUILD_TESTING)
-    set(TESTOPTS -l)
+    # Command line option "-l/--findleaks" of regrtest is deprecated since Python 3.7 and
+    # removed in Python 3.11. It is superseded by --fail-env-changed.
+    set(TESTOPTS $<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>,--fail-env-changed,-l>)
     set(TESTPROG ${PROJECT_BINARY_DIR}/${PYTHONHOME}/test/regrtest.py)
     set(TESTPYTHONOPTS )
       set(TESTPYTHON $<TARGET_FILE:python> ${TESTPYTHONOPTS})

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ How to use this buildsystem:
 
 .. note::
 
-  By default, the build system will download the python 3.10.17 source from
+  By default, the build system will download the python 3.11.12 source from
   http://www.python.org/ftp/python/
 
 
@@ -72,7 +72,7 @@ options on the commandline with `-DOPTION=VALUE`, or use the "ccmake" gui.
 
 ::
 
-  PYTHON_VERSION=major.minor.patch (defaults to 3.10.17)
+  PYTHON_VERSION=major.minor.patch (defaults to 3.11.12)
     The version of Python to build.
 
   PYTHON_APPLY_PATCHES=ON|OFF (defaults to ON)

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -16,6 +16,9 @@ message(STATUS "The system processor is ${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS "The system version is ${CMAKE_SYSTEM_VERSION}")
 
 # Find any dependencies
+
+set(HAVE_LIBB2 0) # See https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/issues/393
+
 if(USE_SYSTEM_BZip2)
     find_package(BZip2) # https://cmake.org/cmake/help/latest/module/FindBZip2.html
 endif()

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -21,6 +21,7 @@ if(USE_SYSTEM_BZip2)
 endif()
 message(STATUS "BZIP2_INCLUDE_DIR=${BZIP2_INCLUDE_DIR}")
 message(STATUS "BZIP2_LIBRARIES=${BZIP2_LIBRARIES}")
+set(HAVE_BZLIB_H "${BZIP2_INCLUDE_DIR}") # Python 3.11
 
 if(USE_SYSTEM_Curses)
 
@@ -104,7 +105,9 @@ if(USE_SYSTEM_TCL)
             message(STATUS "TK_PATCH_LEVEL: ${TK_PATCH_LEVEL}")
 
             set(_tk_expected_version)
-            if(PY_VERSION VERSION_GREATER_EQUAL "3.5")
+            if(PY_VERSION VERSION_GREATER_EQUAL "3.11")
+                set(_tk_expected_version "8.5.12")
+            elseif(PY_VERSION VERSION_GREATER_EQUAL "3.5")
                 set(_tk_expected_version "8.4")
             else()
                 set(_tk_expected_version "8.3.1")
@@ -133,6 +136,7 @@ if(USE_SYSTEM_ZLIB)
     message(STATUS "ZLIB_INCLUDE_DIRS=${ZLIB_INCLUDE_DIRS}")
     message(STATUS "ZLIB_LIBRARIES=${ZLIB_LIBRARIES}")
 endif()
+set(HAVE_ZLIB_H ${ZLIB_INCLUDE_DIRS}) # Python 3.11
 
 if(USE_SYSTEM_DB)
     find_path(DB_INCLUDE_PATH db.h)
@@ -140,21 +144,32 @@ if(USE_SYSTEM_DB)
     message(STATUS "DB_INCLUDE_PATH=${DB_INCLUDE_PATH}")
     message(STATUS "DB_LIBRARY=${DB_LIBRARY}")
 endif()
+set(HAVE_DB_H ${DB_INCLUDE_PATH}) # Python 3.11
+set(HAVE_LIBDB ${DB_LIBRARY}) # Python 3.11
 
 if(USE_SYSTEM_GDBM)
     find_path(GDBM_INCLUDE_PATH gdbm.h)
+    set(HAVE_GDBM_H ${GDBM_INCLUDE_PATH}) # Python 3.11
     find_library(GDBM_LIBRARY gdbm)
     find_library(GDBM_COMPAT_LIBRARY gdbm_compat)
+    set(HAVE_LIBGDBM_COMPAT ${GDBM_COMPAT_LIBRARY}) # Python 3.11
     find_path(NDBM_INCLUDE_PATH ndbm.h)
+    set(HAVE_NDBM_H ${NDBM_INCLUDE_PATH}) # Python 3.11
 
     if(NDBM_INCLUDE_PATH)
         set(NDBM_TAG NDBM)
+        set(NDBM_USE NDBM)
+        find_library(NDBM_LIBRARY ndbm)
+        set(HAVE_LIBNDBM ${NDBM_LIBRARY}) # Python 3.11
     else()
+        set(NDBM_USE GDBM_COMPAT)
         find_path(GDBM_NDBM_INCLUDE_PATH gdbm/ndbm.h)
+        set(HAVE_GDBM_NDBM_H ${GDBM_NDBM_INCLUDE_PATH}) # Python 3.11
         if(GDBM_NDBM_INCLUDE_PATH)
             set(NDBM_TAG GDBM_NDBM)
         else()
             find_path(GDBM_DASH_NDBM_INCLUDE_PATH gdbm-ndbm.h)
+            set(HAVE_GDBM_DASH_NDBM_H ${GDBM_DASH_NDBM_INCLUDE_PATH}) # Python 3.11
             if(GDBM_DASH_NDBM_INCLUDE_PATH)
                 set(NDBM_TAG GDBM_DASH_NDBM)
             endif()
@@ -165,12 +180,14 @@ message(STATUS "GDBM_INCLUDE_PATH=${GDBM_INCLUDE_PATH}")
 message(STATUS "GDBM_LIBRARY=${GDBM_LIBRARY}")
 message(STATUS "GDBM_COMPAT_LIBRARY=${GDBM_COMPAT_LIBRARY}")
 message(STATUS "NDBM_TAG=${NDBM_TAG}")
+message(STATUS "NDBM_USE=${NDBM_USE}")
 message(STATUS "<NDBM_TAG>_INCLUDE_PATH=${${NDBM_TAG}_INCLUDE_PATH}")
 
 find_path(LZMA_INCLUDE_PATH lzma.h)
 find_library(LZMA_LIBRARY lzma)
 message(STATUS "LZMA_INCLUDE_PATH=${LZMA_INCLUDE_PATH}")
 message(STATUS "LZMA_LIBRARY=${LZMA_LIBRARY}")
+set(HAVE_LZMA_H ${LZMA_INCLUDE_PATH}) # Python 3.11
 
 if(USE_SYSTEM_READLINE)
     if(USE_LIBEDIT)
@@ -199,8 +216,10 @@ set(SQLite3_INCLUDE_DIRS ${SQLite3_INCLUDE_DIR})
 set(SQLite3_LIBRARIES ${SQLite3_LIBRARY})
 message(STATUS "SQLite3_INCLUDE_DIRS=${SQLite3_INCLUDE_DIRS}")
 message(STATUS "SQLite3_LIBRARIES=${SQLite3_LIBRARIES}")
+set(HAVE_LIBSQLITE3 ${SQLite3_LIBRARIES}) # Python 3.11
 
 find_path(TIRPC_RPC_INCLUDE_PATH rpc.h PATHS "/usr/include/tirpc/rpc")
+set(HAVE_RPC_RPC_H ${TIRPC_RPC_INCLUDE_PATH}) # Python 3.11
 find_library(TIRPC_LIBRARY tirpc)
 
 find_library(UUID_LIBRARY uuid)
@@ -332,6 +351,7 @@ check_include_files(linux/auxvec.h HAVE_LINUX_AUXVEC_H) # Python 3.10
 check_include_files(locale.h HAVE_LOCALE_H)
 
 check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
+check_include_files(sys/soundcard.h> HAVE_SYS_SOUNDCARD_H) # Python 3.11
 
 set(LINUX_NETLINK_HEADERS)
 add_cond(LINUX_NETLINK_HEADERS HAVE_ASM_TYPES_H  asm/types.h)
@@ -352,6 +372,7 @@ check_include_files("${LINUX_CAN_HEADERS};linux/can.h" HAVE_LINUX_CAN_H)
 check_include_files("${LINUX_CAN_HEADERS};linux/can/bcm.h" HAVE_LINUX_CAN_BCM_H)
 check_include_files("${LINUX_CAN_HEADERS};linux/can/j1939.h" HAVE_LINUX_CAN_J1939_H)
 check_include_files("${LINUX_CAN_HEADERS};linux/can/raw.h" HAVE_LINUX_CAN_RAW_H)
+check_include_files("${LINUX_CAN_HEADERS};netcan/can.h" HAVE_NETCAN_CAN_H) # Python 3.11
 
 set(LINUX_VM_SOCKETS_HEADERS)
 add_cond(LINUX_VM_SOCKETS_HEADERS HAVE_SYS_SOCKET_H sys/socket.h)
@@ -377,6 +398,7 @@ else()
   check_include_files("stdio.h;readline/readline.h" HAVE_READLINE_READLINE_H)
 endif()
 check_include_files(semaphore.h HAVE_SEMAPHORE_H)
+check_include_files(setjmp.h HAVE_SETJMP_H) # Python 3.11
 check_include_files(shadow.h HAVE_SHADOW_H)
 check_include_files(signal.h HAVE_SIGNAL_H)
 check_include_files(spawn.h HAVE_SPAWN_H)
@@ -386,6 +408,7 @@ check_include_files(strings.h HAVE_STRINGS_H) # libffi and cpython
 check_include_files(string.h HAVE_STRING_H)   # libffi and cpython
 check_include_files(stropts.h HAVE_STROPTS_H)
 check_include_files(sysexits.h HAVE_SYSEXITS_H)
+check_include_files(syslog.h HAVE_SYSLOG_H) # Python 3.11
 check_include_files(sys/audioio.h HAVE_SYS_AUDIOIO_H)
 check_include_files(sys/auxv.h HAVE_SYS_AUXV_H) # Python 3.10
 check_include_files(sys/bsdtty.h HAVE_SYS_BSDTTY_H)
@@ -419,6 +442,7 @@ check_include_files(term.h HAVE_TERM_H)
 check_include_files(unistd.h HAVE_UNISTD_H) # libffi and cpython
 check_include_files(util.h HAVE_UTIL_H)
 check_include_files(utime.h HAVE_UTIME_H)
+check_include_files(utmp.h HAVE_UTMP_H) # Python 3.11
 check_include_files(wchar.h HAVE_WCHAR_H)
 check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS) # libffi and cpython
 
@@ -426,8 +450,10 @@ check_include_files(stdarg.h HAVE_STDARG_PROTOTYPES)
 
 check_include_files(endian.h HAVE_ENDIAN_H)
 check_include_files(sched.h HAVE_SCHED_H)
+check_include_files(linux/limits.h HAVE_LINUX_LIMITS_H) # Python 3.11
 check_include_files(linux/memfd.h HAVE_LINUX_MEMFD_H)
 check_include_files(linux/random.h HAVE_LINUX_RANDOM_H)
+check_include_files(linux/soundcard.h HAVE_LINUX_SOUNDCARD_H) # Python 3.11
 check_include_files(sys/devpoll.h HAVE_SYS_DEVPOLL_H)
 check_include_files(sys/endian.h HAVE_SYS_ENDIAN_H)
 check_include_files(sys/ioctl.h HAVE_SYS_IOCTL_H)
@@ -872,6 +898,7 @@ check_symbol_exists(confstr      "${CFG_HEADERS}" HAVE_CONFSTR)
 check_symbol_exists(connect      "${CFG_HEADERS}" HAVE_CONNECT) # Python 3.11
 check_symbol_exists(ctermid      "${CFG_HEADERS}" HAVE_CTERMID)
 check_symbol_exists(ctermid_r    "${CFG_HEADERS}" HAVE_CTERMID_R)
+check_symbol_exists(dup          "${CFG_HEADERS}" HAVE_DUP) # Python 3.11
 check_symbol_exists(dup2         "${CFG_HEADERS}" HAVE_DUP2)
 check_symbol_exists(epoll_create "${CFG_HEADERS}" HAVE_EPOLL)
 check_symbol_exists(epoll_create1 "${CFG_HEADERS}" HAVE_EPOLL_CREATE1)
@@ -885,6 +912,7 @@ if(NOT HAVE_FLOCK)
   check_library_exists(bsd flock "" FLOCK_NEEDS_LIBBSD)
 endif()
 check_symbol_exists(fork         "${CFG_HEADERS}" HAVE_FORK)
+check_symbol_exists(fork1        "${CFG_HEADERS}" HAVE_FORK1) # Python 3.11
 check_symbol_exists(forkpty      "${CFG_HEADERS}" HAVE_FORKPTY)
 check_symbol_exists(fpathconf    "${CFG_HEADERS}" HAVE_FPATHCONF)
 cmake_push_check_state()
@@ -939,6 +967,7 @@ python_check_function(lchmod HAVE_LCHMOD)
 check_symbol_exists(lchown       "${CFG_HEADERS}" HAVE_LCHOWN)
 check_symbol_exists(link         "${CFG_HEADERS}" HAVE_LINK)
 check_symbol_exists(listen       "${CFG_HEADERS}" HAVE_LISTEN) # Python 3.11
+check_symbol_exists(login_tty    "${CFG_HEADERS}" HAVE_LOGIN_TTY) # Python 3.11
 check_symbol_exists(lstat        "${CFG_HEADERS}" HAVE_LSTAT)
 check_symbol_exists(makedev      "${CFG_HEADERS}" HAVE_MAKEDEV)
 check_symbol_exists(memcpy       "${CFG_HEADERS}" HAVE_MEMCPY) # libffi and cpython
@@ -1033,10 +1062,12 @@ check_symbol_exists(futimes      "${CFG_HEADERS}" HAVE_FUTIMES)
 check_symbol_exists(futimesat    "${CFG_HEADERS}" HAVE_FUTIMESAT)
 check_symbol_exists(getentropy   "${CFG_HEADERS}" HAVE_GETENTROPY)
 python_check_function(getpriority HAVE_GETPRIORITY)
+check_symbol_exists(getgrgid     "${CFG_HEADERS}" HAVE_GETGRGID) # Python 3.11
 check_symbol_exists(getgrgid_r   "${CFG_HEADERS}" HAVE_GETGRGID_R)
 check_symbol_exists(getgrnam_r   "${CFG_HEADERS}" HAVE_GETGRNAM_R)
 check_symbol_exists(getgrouplist "${CFG_HEADERS}" HAVE_GETGROUPLIST)
 check_symbol_exists(getpwnam_r   "${CFG_HEADERS}" HAVE_GETPWNAM_R)
+check_symbol_exists(getpwuid     "${CFG_HEADERS}" HAVE_GETPWUID) # Python 3.11
 check_symbol_exists(getpwuid_r   "${CFG_HEADERS}" HAVE_GETPWUID_R)
 check_symbol_exists(htole64      "${CFG_HEADERS}" HAVE_HTOLE64)
 check_symbol_exists(if_nameindex "${CFG_HEADERS}" HAVE_IF_NAMEINDEX)
@@ -1720,6 +1751,50 @@ if(NOT HAVE_CLOCK_SETTIME)
   endif()
 endif()
 
+if(NOT HAVE_CLOCK_NANOSLEEP)
+  cmake_push_check_state()
+  set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_lib_rt_clock_nanosleep.c)
+  file(WRITE ${check_src} "/* Override any GCC internal prototype to avoid an error.
+  Use char because int might match the return type of a GCC
+  builtin and then its argument prototype would still apply.  */
+  #ifdef __cplusplus
+  extern \"C\"
+  #endif
+  char clock_nanosleep ();
+  int main () { return clock_nanosleep (); }
+  ")
+  list(APPEND CMAKE_REQUIRED_LIBRARIES rt)
+  python_platform_test(
+    HAVE_CLOCK_NANOSLEEP
+    "Checking for clock_nanosleep in -lrt"
+    ${check_src}
+    DIRECT
+    )
+  cmake_pop_check_state()
+endif()
+
+if(NOT HAVE_NANOSLEEP)
+  cmake_push_check_state()
+  set(check_src ${PROJECT_BINARY_DIR}/CMakeFiles/ac_cv_lib_rt_nanosleep.c)
+  file(WRITE ${check_src} "/* Override any GCC internal prototype to avoid an error.
+  Use char because int might match the return type of a GCC
+  builtin and then its argument prototype would still apply.  */
+  #ifdef __cplusplus
+  extern \"C\"
+  #endif
+  char nanosleep ();
+  int main () { return nanosleep (); }
+  ")
+  list(APPEND CMAKE_REQUIRED_LIBRARIES rt)
+  python_platform_test(
+    HAVE_NANOSLEEP
+    "Checking for nanosleep in -lrt"
+    ${check_src}
+    DIRECT
+    )
+  cmake_pop_check_state()
+endif()
+
 #######################################################################
 #
 # unicode
@@ -1921,6 +1996,8 @@ check_symbol_exists(getaddrinfo     "${CFG_HEADERS}" HAVE_GETADDRINFO)
 check_symbol_exists(gethostname     "${CFG_HEADERS}" HAVE_GETHOSTNAME) # Python 3.11
 check_symbol_exists(getnameinfo     "${CFG_HEADERS}" HAVE_GETNAMEINFO)
 check_symbol_exists(gethostbyaddr   "${CFG_HEADERS}" HAVE_GETHOSTBYADDR) # Python 3.11
+check_symbol_exists(getprotobyname  "${CFG_HEADERS}" HAVE_GETPROTOBYNAME) # Python 3.11
+
 check_symbol_exists(getpeername     "${CFG_HEADERS}" HAVE_GETPEERNAME)
 check_symbol_exists(getservbyname   "${CFG_HEADERS}" HAVE_GETSERVBYNAME) # Python 3.11
 check_symbol_exists(getservbyport   "${CFG_HEADERS}" HAVE_GETSERVBYPORT) # Python 3.11
@@ -1929,6 +2006,7 @@ check_symbol_exists(inet_aton       "${CFG_HEADERS}" HAVE_INET_ATON)
 if(NOT HAVE_INET_ATON)
   check_library_exists(resolv inet_aton "" HAVE_LIBRESOLV)
 endif()
+check_symbol_exists(inet_ntoa       "${CFG_HEADERS}" HAVE_INET_NTOA) # Python 3.11
 check_symbol_exists(inet_pton       "${CFG_HEADERS}" HAVE_INET_PTON)
 
 set(CMAKE_EXTRA_INCLUDE_FILES ${CFG_HEADERS})
@@ -2092,6 +2170,7 @@ if(HAVE_READLINE_READLINE_H)
   add_cond(CMAKE_REQUIRED_LIBRARIES HAVE_LIBREADLINE ${HAVE_LIBREADLINE})
   check_symbol_exists(rl_callback_handler_install "${CFG_HEADERS}" HAVE_RL_CALLBACK)
   check_symbol_exists(rl_catch_signals            "${CFG_HEADERS}" HAVE_RL_CATCH_SIGNAL)
+  check_symbol_exists(rl_compdisp_func_t          "${CFG_HEADERS}" HAVE_RL_COMPDISP_FUNC_T) # Python 3.11
   check_symbol_exists(rl_completion_append_character     "${CFG_HEADERS}" HAVE_RL_COMPLETION_APPEND_CHARACTER)
   check_symbol_exists(rl_completion_display_matches_hook "${CFG_HEADERS}" HAVE_RL_COMPLETION_DISPLAY_MATCHES_HOOK)
   check_symbol_exists(rl_completion_suppress_append      "${CFG_HEADERS}" HAVE_RL_COMPLETION_SUPPRESS_APPEND)

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -777,6 +777,9 @@ add_cond(CMAKE_EXTRA_INCLUDE_FILES HAVE_WCHAR_H wchar.h)
 
 TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
 
+# Assume C89 semantics that RETSIGTYPE is always void
+set(RETSIGTYPE "void")
+
 check_type_size(double SIZEOF_DOUBLE) # libffi and cpython
 check_type_size(float SIZEOF_FLOAT)
 check_type_size(fpos_t SIZEOF_FPOS_T)

--- a/cmake/config-mingw/pyconfig.h
+++ b/cmake/config-mingw/pyconfig.h
@@ -387,6 +387,9 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Use Python's own small-block memory-allocator. */
 #define WITH_PYMALLOC 1
 
+/* Define if you want to compile in object freelists optimization [Python 3.11] */
+#define WITH_FREELISTS 1
+
 /* Define if you have clock.  */
 /* #define HAVE_CLOCK */
 

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1950,6 +1950,15 @@
    #define below would cause a syntax error. */
 /* #undef _UINT64_T */
 
+/* Define to 1 if you want to emulate getpid() on WASI [Python 3.11] */
+/* #undef _WASI_EMULATED_GETPID */
+
+/* Define to 1 if you want to emulate process clocks on WASI [Python 3.11] */
+/* #undef _WASI_EMULATED_PROCESS_CLOCKS */
+
+/* Define to 1 if you want to emulate signals on WASI [Python 3.11] */
+/* #undef _WASI_EMULATED_SIGNAL */
+
 /* Define to the level of X/Open that your system supports */
 #cmakedefine _XOPEN_SOURCE @_XOPEN_SOURCE@
 

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1709,6 +1709,9 @@
 /* Define if you want to enable tracing references for debugging purpose [Python 3.8] */
 #cmakedefine Py_TRACE_REFS 1
 
+/* assume C89 semantics that RETSIGTYPE is always void */
+#cmakedefine RETSIGTYPE
+
 /* Define if setpgrp() must be called as setpgrp(0, 0). */
 #cmakedefine SETPGRP_HAVE_ARG 1
 

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -696,6 +696,9 @@
 /* Define to 1 if you have the `lchown' function. */
 #cmakedefine HAVE_LCHOWN 1
 
+/* Define to 1 if you want to build _blake2 module with libb2 [Python 3.11] */
+#cmakedefine HAVE_LIBB2 1
+
 /* Define to 1 if you have the `db' library (-ldb). [Python 3.11] */
 #cmakedefine HAVE_LIBDB 1
 

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -994,6 +994,9 @@
 /* Define to 1 if you have the `pthread_sigmask' function. */
 #cmakedefine HAVE_PTHREAD_SIGMASK 1
 
+/* Define if platform requires stubbed pthreads support [Python 3.11] */
+/* #undef HAVE_PTHREAD_STUBS */
+
 /* Define to 1 if you have the <pty.h> header file. */
 #cmakedefine HAVE_PTY_H 1
 

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -59,6 +59,9 @@
    the case on Motorola V4 (R40V4.2) */
 #cmakedefine GETTIMEOFDAY_NO_TZ 1
 
+/* Define to 1 if you have the `accept' function. [Python 3.11] */
+#cmakedefine HAVE_ACCEPT 1
+
 /* Define to 1 if you have the `accept4' function. [Python 3] */
 #cmakedefine HAVE_ACCEPT4 1
 
@@ -88,6 +91,9 @@
 
 /* Define to 1 if you have the `atanh' function. */
 #cmakedefine HAVE_ATANH 1
+
+/* Define to 1 if you have the `bind' function. [Python 3.11] */
+#cmakedefine HAVE_BIND 1
 
 /* Define to 1 if you have the `bind_textdomain_codeset' function. */
 #cmakedefine HAVE_BIND_TEXTDOMAIN_CODESET 1
@@ -129,8 +135,14 @@
 /* Define this if you have the type _Bool. */
 #cmakedefine HAVE_C99_BOOL 1
 
+/* Define to 1 if you have the <bzlib.h> header file. [Python 3.11] */
+#cmakedefine HAVE_BZLIB_H 1
+
 /* Define to 1 if you have the 'chflags' function. */
 #cmakedefine HAVE_CHFLAGS 1
+
+/* Define to 1 if you have the `chmod' function. [Python 3.11] */
+#cmakedefine HAVE_CHMOD 1
 
 /* Define to 1 if you have the `chown' function. */
 #cmakedefine HAVE_CHOWN 1
@@ -147,6 +159,9 @@
 /* Define to 1 if you have the `clock_gettime' function. [Python 3] */
 #cmakedefine HAVE_CLOCK_GETTIME 1
 
+/* Define to 1 if you have the `clock_nanosleep' function. [Python 3.11] */
+#cmakedefine HAVE_CLOCK_NANOSLEEP 1
+
 /* Define to 1 if you have the `clock_settime' function. [Python 3.6] */
 #cmakedefine HAVE_CLOCK_SETTIME 1
 
@@ -161,6 +176,9 @@
 
 /* Define to 1 if you have the <conio.h> header file. */
 #cmakedefine HAVE_CONIO_H 1
+
+/* Define to 1 if you have the `connect' function. [Python 3.11] */
+#cmakedefine HAVE_CONNECT 1
 
 /* Define to 1 if you have the `copysign' function. */
 #cmakedefine HAVE_COPYSIGN 1
@@ -215,6 +233,9 @@
 
 /* Define if you have the 'wchgat' function. [Python 3.6] */
 #cmakedefine HAVE_CURSES_WCHGAT 1
+
+/* Define to 1 if you have the <db.h> header file. [Python 3.11] */
+#cmakedefine HAVE_DB_H 1
 
 /* Define to 1 if you have the declaration of `isfinite', and to 0 if you
    don't. */
@@ -291,6 +312,9 @@
 
 /* Define to 1 if you have the `dlopen' function. */
 #cmakedefine HAVE_DLOPEN 1
+
+/* Define to 1 if you have the `dup' function. [Python 3.11] */
+#cmakedefine HAVE_DUP 1
 
 /* Define to 1 if you have the `dup2' function. */
 #cmakedefine HAVE_DUP2 1
@@ -379,6 +403,9 @@
 /* Define to 1 if you have the `fork' function. */
 #cmakedefine HAVE_FORK 1
 
+/* Define to 1 if you have the `fork1' function. [Python 3.11] */
+#cmakedefine HAVE_FORK1 1
+
 /* Define to 1 if you have the `forkpty' function. */
 #cmakedefine HAVE_FORKPTY 1
 
@@ -440,14 +467,35 @@
 /* Define if your compiler provides __uint128_t [Python 3] */
 #cmakedefine HAVE_GCC_UINT128_T 1
 
+/* Define to 1 if you have the <gdbm-ndbm.h> header file. [Python 3.11] */
+#cmakedefine HAVE_GDBM_DASH_NDBM_H 1
+
+/* Define to 1 if you have the <gdbm.h> header file. [Python 3.11] */
+#cmakedefine HAVE_GDBM_H 1
+
+/* Define to 1 if you have the <gdbm/ndbm.h> header file. [Python 3.11] */
+#cmakedefine HAVE_GDBM_NDBM_H 1
+
 /* Define if you have the getaddrinfo function. */
 #cmakedefine HAVE_GETADDRINFO 1
 
 /* Define this if you have flockfile(), getc_unlocked(), and funlockfile() */
 #cmakedefine HAVE_GETC_UNLOCKED 1
 
+/* Define to 1 if you have the `getegid' function. [Python 3.11] */
+#cmakedefine HAVE_GETEGID 1
+
+/* Define to 1 if you have the `geteuid' function. [Python 3.11] */
+#cmakedefine HAVE_GETEUID 1
+
 /* Define to 1 if you have the `getentropy' function. [Python 3] */
 #cmakedefine HAVE_GETENTROPY 1
+
+/* Define to 1 if you have the `getgid' function. [Python 3.11] */
+#cmakedefine HAVE_GETGID 1
+
+/* Define to 1 if you have the `getgrgid' function. [Python 3.11] */
+#cmakedefine HAVE_GETGRGID 1
 
 /* Define to 1 if you have the `getgrgid_r' function. [Python 3.8] */
 #cmakedefine HAVE_GETGRGID_R 1
@@ -460,6 +508,9 @@
 
 /* Define to 1 if you have the `getgroups' function. */
 #cmakedefine HAVE_GETGROUPS 1
+
+/* Define to 1 if you have the `gethostbyaddr' function. [Python 3.11] */
+#cmakedefine HAVE_GETHOSTBYADDR 1
 
 /* Define to 1 if you have the `gethostbyname' function. */
 #cmakedefine HAVE_GETHOSTBYNAME 1
@@ -475,6 +526,9 @@
 
 /* Define this if you have the 6-arg version of gethostbyname_r(). */
 #cmakedefine HAVE_GETHOSTBYNAME_R_6_ARG 1
+
+/* Define if you have the gethostname function. [Python 3.11] */
+#cmakedefine HAVE_GETHOSTNAME 1
 
 /* Define to 1 if you have the `getitimer' function. */
 #cmakedefine HAVE_GETITIMER 1
@@ -503,14 +557,23 @@
 /* Define to 1 if you have the `getpid' function. */
 #cmakedefine HAVE_GETPID 1
 
+/* Define if you have the 'getppid' function. [Python 3.11] */
+#cmakedefine HAVE_GETPPID 1
+
 /* Define to 1 if you have the `getpriority' function. */
 #cmakedefine HAVE_GETPRIORITY 1
+
+/* Define if you have the 'getprotobyname' function. [Python 3.11] */
+#cmakedefine HAVE_GETPROTOBYNAME 1
 
 /* Define to 1 if you have the `getpwent' function. */
 #cmakedefine HAVE_GETPWENT 1
 
 /* Define to 1 if you have the `getpwnam_r' function. [Python 3.8] */
 #cmakedefine HAVE_GETPWNAM_R 1
+
+/* Define to 1 if you have the `getpwuid' function. [Python 3.11] */
+#cmakedefine HAVE_GETPWUID 1
 
 /* Define to 1 if you have the `getpwuid_r' function. [Python 3.8] */
 #cmakedefine HAVE_GETPWUID_R 1
@@ -527,8 +590,20 @@
 /* Define to 1 if you have the `getresuid' function. */
 #cmakedefine HAVE_GETRESUID 1
 
+/* Define to 1 if you have the `getrusage' function. [Python 3.11] */
+#cmakedefine HAVE_GETRUSAGE 1
+
+/* Define to 1 if you have the `getservbyname' function. [Python 3.11] */
+#cmakedefine HAVE_GETSERVBYNAME 1
+
+/* Define if you have the 'getservbyport' function. [Python 3.11] */
+#cmakedefine HAVE_GETSERVBYPORT 1
+
 /* Define to 1 if you have the `getsid' function. */
 #cmakedefine HAVE_GETSID 1
+
+/* Define to 1 if you have the `getsockname' function. [Python 3.11] */
+#cmakedefine HAVE_GETSOCKNAME 1
 
 /* Define to 1 if you have the `getspent' function. */
 #cmakedefine HAVE_GETSPENT 1
@@ -538,6 +613,9 @@
 
 /* Define to 1 if you have the `gettimeofday' function. */
 #cmakedefine HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the `getuid' function. [Python 3.11] */
+#cmakedefine HAVE_GETUID 1
 
 /* Define to 1 if you have the `getwd' function. */
 #cmakedefine HAVE_GETWD 1
@@ -566,6 +644,9 @@
 
 /* Define if you have the 'inet_aton' function. */
 #cmakedefine HAVE_INET_ATON 1
+
+/* Define if you have the 'inet_ntoa' function. [Python 3.11] */
+#cmakedefine HAVE_INET_NTOA 1
 
 /* Define if you have the 'inet_pton' function. */
 #cmakedefine HAVE_INET_PTON 1
@@ -615,6 +696,9 @@
 /* Define to 1 if you have the `lchown' function. */
 #cmakedefine HAVE_LCHOWN 1
 
+/* Define to 1 if you have the `db' library (-ldb). [Python 3.11] */
+#cmakedefine HAVE_LIBDB 1
+
 /* Define to 1 if you have the `lgamma' function. */
 #cmakedefine HAVE_LGAMMA 1
 
@@ -624,11 +708,17 @@
 /* Define to 1 if you have the `dld' library (-ldld). */
 #cmakedefine HAVE_LIBDLD 1
 
+/* Define to 1 if you have the `gdbm_compat' library (-lgdbm_compat). [Python 3.11] */
+#cmakedefine HAVE_LIBGDBM_COMPAT 1
+
 /* Define to 1 if you have the `ieee' library (-lieee). */
 #cmakedefine HAVE_LIBIEEE 1
 
 /* Define to 1 if you have the <libintl.h> header file. */
 #cmakedefine HAVE_LIBINTL_H 1
+
+/* Define to 1 if you have the `ndbm' library (-lndbm). [Python 3.11] */
+#cmakedefine HAVE_LIBNDBM 1
 
 /* Define if you have the readline library (-lreadline). */
 #cmakedefine HAVE_LIBREADLINE 1
@@ -638,6 +728,9 @@
 
 /* Define to 1 if you have the `sendfile' library (-lsendfile). [Python 3] */
 #cmakedefine HAVE_LIBSENDFILE 1
+
+/* Define to 1 if you have the `sqlite3' library (-lsqlite3). [Python 3.11] */
+#cmakedefine HAVE_LIBSQLITE3 1
 
 /* Define to 1 if you have the <libutil.h> header file. */
 #cmakedefine HAVE_LIBUTIL_H 1
@@ -672,6 +765,9 @@
 /* Define if compiling using Linux 4.1 or later. [Python 3.9] */
 #cmakedefine HAVE_LINUX_CAN_RAW_JOIN_FILTERS 1
 
+/* Define to 1 if you have the <linux/limits.h> header file. [Python 3.11] */
+#cmakedefine HAVE_LINUX_LIMITS_H 1
+
 /* Define to 1 if you have the <linux/memfd.h> header file. [Python 3.8] */
 #cmakedefine HAVE_LINUX_MEMFD_H 1
 
@@ -684,6 +780,9 @@
 /* Define to 1 if you have the <linux/random.h> header file. */
 #cmakedefine HAVE_LINUX_RANDOM_H 1
 
+/* Define to 1 if you have the <linux/soundcard.h> header file. [Python 3.11] */
+#cmakedefine HAVE_LINUX_SOUNDCARD_H 1
+
 /* Define to 1 if you have the <linux/tipc.h> header file. */
 #cmakedefine HAVE_LINUX_TIPC_H 1
 
@@ -693,6 +792,9 @@
 /* Define to 1 if you have the <linux/wait.h> header file. [Python 3.9] */
 #cmakedefine HAVE_LINUX_WAIT_H 1
 
+/* Define to 1 if you have the `listen' function. [Python 3.11] */
+#cmakedefine HAVE_LISTEN 1
+
 /* Define to 1 if you have the `lockf' function. [Python 3] */
 #cmakedefine HAVE_LOCKF 1
 
@@ -701,6 +803,9 @@
 
 /* Define to 1 if you have the `log2' function. [Python 3] */
 #cmakedefine HAVE_LOG2 1
+
+/* Define to 1 if you have the `login_tty' function. [Python 3.11] */
+#cmakedefine HAVE_LOGIN_TTY 1
 
 /* Define this if you have the type long double. */
 #cmakedefine HAVE_LONG_DOUBLE 1
@@ -713,6 +818,9 @@
 
 /* Define to 1 if you have the `lutimes' function. [Python 3] */
 #cmakedefine HAVE_LUTIMES 1
+
+/* Define to 1 if you have the <lzma.h> header file. [Python 3.11] */
+#cmakedefine HAVE_LZMA_H 1
 
 /* Define to 1 if you have the `madvise' function. [Python 3.8] */
 #cmakedefine HAVE_MADVISE 1
@@ -759,11 +867,26 @@
 /* Define to 1 if you have the `mremap' function. */
 #cmakedefine HAVE_MREMAP 1
 
+/* Define to 1 if you have the `nanosleep' function. [Python 3.11] */
+#cmakedefine HAVE_NANOSLEEP 1
+
 /* Define to 1 if you have the <ncurses.h> header file. */
 #cmakedefine HAVE_NCURSES_H 1
 
+/* Define to 1 if you have the <ndbm.h> header file. [Python 3.11] */
+#cmakedefine HAVE_NDBM_H 1
+
 /* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #cmakedefine HAVE_NDIR_H 1
+
+/* Define to 1 if you have the <netcan/can.h> header file. [Python 3.11] */
+#cmakedefine HAVE_NETCAN_CAN_H 1
+
+/* Define to 1 if you have the <netdb.h> header file. [Python 3.11] */
+#cmakedefine HAVE_NETDB_H 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. [Python 3.11] */
+#cmakedefine HAVE_NETINET_IN_H 1
 
 /* Define to 1 if you have the <netpacket/packet.h> header file. */
 #cmakedefine HAVE_NETPACKET_PACKET_H 1
@@ -781,6 +904,9 @@
 /* Define to 1 if you have the `openat' function. [Python 3] */
 #cmakedefine HAVE_OPENAT 1
 
+/* Define to 1 if you have the `opendir' function. [Python 3.11] */
+#cmakedefine HAVE_OPENDIR 1
+
 /* Define to 1 if you have the `openpty' function. */
 #cmakedefine HAVE_OPENPTY 1
 
@@ -792,6 +918,9 @@
 
 /* Define to 1 if you have the `pause' function. */
 #cmakedefine HAVE_PAUSE 1
+
+/* Define to 1 if you have the `pipe' function. [Python 3.11] */
+#cmakedefine HAVE_PIPE 1
 
 /* Define to 1 if you have the `pipe2' function. [Python 3] */
 #cmakedefine HAVE_PIPE2 1
@@ -892,6 +1021,9 @@
 /* Define to 1 if you have the `realpath' function. */
 #cmakedefine HAVE_REALPATH 1
 
+/* Define to 1 if you have the `recvfrom' function. [Python 3.11] */
+#cmakedefine HAVE_RECVFROM 1
+
 /* Define to 1 if you have the `renameat' function. [Python 3] */
 #cmakedefine HAVE_RENAMEAT 1
 
@@ -903,6 +1035,9 @@
 
 /* Define if you can turn off readline's signal handling. */
 #cmakedefine HAVE_RL_CATCH_SIGNAL 1
+
+/* Define if readline supports rl_compdisp_func_t [Python 3.11] */
+#cmakedefine HAVE_RL_COMPDISP_FUNC_T 1
 
 /* Define if you have readline 2.2 */
 #cmakedefine HAVE_RL_COMPLETION_APPEND_CHARACTER 1
@@ -924,6 +1059,9 @@
 
 /* Define to 1 if you have the `round' function. */
 #cmakedefine HAVE_ROUND 1
+
+/* Define to 1 if you have the <rpc/rpc.h> header file. [Python 3.11] */
+#cmakedefine HAVE_RPC_RPC_H 1
 
 /* Define to 1 if you have the `rtpSpawn' function. [Python 3.8] */
 #cmakedefine HAVE_RTPSPAWN 1
@@ -967,6 +1105,9 @@
 /* Define to 1 if you have the `sendfile' function. [Python 3] */
 #cmakedefine HAVE_SENDFILE 1
 
+/* Define to 1 if you have the `sendto' function. [Python 3.11] */
+#cmakedefine HAVE_SENDTO 1
+
 /* Define to 1 if you have the `setegid' function. */
 #cmakedefine HAVE_SETEGID 1
 
@@ -984,6 +1125,9 @@
 
 /* Define to 1 if you have the `setitimer' function. */
 #cmakedefine HAVE_SETITIMER 1
+
+/* Define to 1 if you have the <setjmp.h> header file. [Python 3.11] */
+#cmakedefine HAVE_SETJMP_H 1
 
 /* Define to 1 if you have the `setlocale' function. */
 #cmakedefine HAVE_SETLOCALE 1
@@ -1012,6 +1156,9 @@
 /* Define to 1 if you have the `setsid' function. */
 #cmakedefine HAVE_SETSID 1
 
+/* Define to 1 if you have the `setsockopt' function. [Python 3.11] */
+#cmakedefine HAVE_SETSOCKOPT 1
+
 /* Define to 1 if you have the `setuid' function. */
 #cmakedefine HAVE_SETUID 1
 
@@ -1026,6 +1173,9 @@
 
 /* Define to 1 if you have the `shm_unlink' function. [Python 3.8] */
 #cmakedefine HAVE_SHM_UNLINK 1
+
+/* Define to 1 if you have the `shutdown' function. [Python 3.11] */
+#cmakedefine HAVE_SHUTDOWN 1
 
 /* Define to 1 if you have the `sigaction' function. */
 #cmakedefine HAVE_SIGACTION 1
@@ -1074,6 +1224,9 @@
 
 /* struct sockaddr_storage (sys/socket.h) */
 #cmakedefine HAVE_SOCKADDR_STORAGE 1
+
+/* Define if you have the 'socket' function. [Python 3.11] */
+#cmakedefine HAVE_SOCKET 1
 
 /* Define if you have the 'socketpair' function. */
 #cmakedefine HAVE_SOCKETPAIR 1
@@ -1176,6 +1329,12 @@
 /* Define to 1 if you have the <sysexits.h> header file. */
 #cmakedefine HAVE_SYSEXITS_H 1
 
+/* Define to 1 if you have the <syslog.h> header file. [Python 3.11] */
+#cmakedefine HAVE_SYSLOG_H 1
+
+/* Define to 1 if you have the `system' function. [Python 3.11] */
+#cmakedefine HAVE_SYSTEM 1
+
 /* Define to 1 if you have the <sys/audioio.h> header file. */
 #cmakedefine HAVE_SYS_AUDIOIO_H 1
 
@@ -1255,6 +1414,9 @@
 
 /* Define to 1 if you have the <sys/socket.h> header file. */
 #cmakedefine HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/soundcard.h> header file. [Python 3.11] */
+#cmakedefine HAVE_SYS_SOUNDCARD_H 1
 
 /* Define to 1 if you have the <sys/statvfs.h> header file. */
 #cmakedefine HAVE_SYS_STATVFS_H 1
@@ -1338,6 +1500,9 @@
 /* Define to 1 if you have the `truncate' function. */
 #cmakedefine HAVE_TRUNCATE 1
 
+/* Define to 1 if you have the `ttyname' function. [Python 3.11] */
+#cmakedefine HAVE_TTYNAME 1
+
 /* Define to 1 if you don't have `tm_zone' but do have the external array
    `tzname'. */
 #cmakedefine HAVE_TZNAME 1
@@ -1353,6 +1518,9 @@
 
 /* Define to 1 if the system has the type `uintptr_t'. */
 #cmakedefine HAVE_UINTPTR_T 1
+
+/* Define to 1 if you have the `umask' function. [Python 3.11] */
+#cmakedefine HAVE_UMASK 1
 
 /* Define to 1 if you have the `uname' function. */
 #cmakedefine HAVE_UNAME 1
@@ -1383,6 +1551,9 @@
 /* Define to 1 if you have the <utime.h> header file. */
 #cmakedefine HAVE_UTIME_H 1
 
+/* Define to 1 if you have the <utmp.h> header file. [Python 3.11] */
+#cmakedefine HAVE_UTMP_H 1
+
 /* Define if uuid_create() exists. [Python 3.7] */
 #cmakedefine HAVE_UUID_CREATE 1
 
@@ -1400,6 +1571,9 @@
 
 /* Define to 1 if you have the `vfork' function. [Python 3.10] */
 #cmakedefine HAVE_VFORK 1
+
+/* Define to 1 if you have the `wait' function. [Python 3.11] */
+#cmakedefine HAVE_WAIT 1
 
 /* Define to 1 if you have the `wait3' function. */
 #cmakedefine HAVE_WAIT3 1
@@ -1440,6 +1614,9 @@
 
 /* Define if the zlib library has inflateCopy */
 #cmakedefine HAVE_ZLIB_COPY 1
+
+/* Define to 1 if you have the <zlib.h> header file. [Python 3.11] */
+#cmakedefine HAVE_ZLIB_H 1
 
 /* Define to 1 if you have the `_getpty' function. */
 #cmakedefine HAVE__GETPTY 1
@@ -1668,6 +1845,9 @@
 
 /* Define to build the readline module against Editline. [Python 3.10] */
 #cmakedefine WITH_EDITLINE 1
+
+/* Define if you want to compile in object freelists optimization [Python 3.11] */
+#cmakedefine WITH_FREELISTS 1
 
 /* Define to 1 if libintl is needed for locale functions. */
 #cmakedefine WITH_LIBINTL 1

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -442,6 +442,8 @@ add_python_extension(_msi
         WIN32
     SOURCES
         ${SRC_DIR}/PC/_msi.c
+    DEFINITIONS
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:NEEDS_PY_IDENTIFIER>
     LIBRARIES
         cabinet.lib
         msi.lib

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -55,7 +55,7 @@ add_python_extension(_bisect ${WIN32_BUILTIN} SOURCES _bisectmodule.c)
 add_python_extension(cmath
     REQUIRES HAVE_LIBM ${WIN32_BUILTIN}
     SOURCES
-        _math.c
+        $<$<VERSION_LESS:${PY_VERSION},3.11>:_math.c>
         cmathmodule.c
     LIBRARIES
         ${M_LIBRARIES})
@@ -124,7 +124,7 @@ add_python_extension(math ${WIN32_BUILTIN}
     REQUIRES
         HAVE_LIBM
     SOURCES
-        _math.c
+        $<$<VERSION_LESS:${PY_VERSION},3.11>:_math.c>
         mathmodule.c
     LIBRARIES
         ${M_LIBRARIES}
@@ -199,7 +199,8 @@ add_python_extension(_pickle ${WIN32_BUILTIN} REQUIRES SOURCES _pickle.c)
 # Fredrik Lundh's new regular expressions
 add_python_extension(_sre BUILTIN
     SOURCES
-        _sre.c
+        $<$<VERSION_LESS:${PY_VERSION},3.11>:_sre.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:_sre/sre.c>
 )
 
 # stat.h interface
@@ -914,6 +915,7 @@ add_python_extension(_dbm
     SOURCES _dbmmodule.c
     DEFINITIONS
         HAVE_${NDBM_TAG}_H
+        USE_${NDBM_USE} # Python 3.11
     LIBRARIES
         ${GDBM_LIBRARY}
         ${GDBM_COMPAT_LIBRARY}
@@ -961,7 +963,9 @@ add_python_extension(readline
 add_python_extension(_sqlite3
     REQUIRES SQLite3_INCLUDE_DIRS SQLite3_LIBRARIES
     SOURCES
-        _sqlite/cache.c
+        # Removed in Python 3.11
+        $<$<VERSION_LESS:${PY_VERSION},3.11>:_sqlite/cache.c>
+
         _sqlite/connection.c
         _sqlite/cursor.c
         _sqlite/microprotocols.c
@@ -970,6 +974,10 @@ add_python_extension(_sqlite3
         _sqlite/row.c
         _sqlite/statement.c
         _sqlite/util.c
+
+        # Introduced in Python 3.11
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:_sqlite/blob.c>
+
     DEFINITIONS
         MODULE_NAME="sqlite3"
         SQLITE_OMIT_LOAD_EXTENSION=1

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -819,6 +819,11 @@ set(LIBPYTHON_SOURCES
     $<$<AND:$<BOOL:${WIN32}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>>:${SRC_DIR}/PC/dl_nt.c>
 )
 if(WIN32 AND PY_VERSION VERSION_GREATER_EQUAL "3.11")
+    set(PYTHONPATH "${EXTRA_PYTHONPATH}\\\;${LIBDIR}\\\\lib-dynload")
+    set(PYTHONPATH "${PYTHONPATH}\\\;${LIBDIR}\\\\lib-dynload\\\\$<CONFIG>")
+
+    set(_wide_char_modifier "L")
+
     set_property(
         SOURCE ${SRC_DIR}/Modules/getpath.c
         PROPERTY COMPILE_DEFINITIONS
@@ -827,8 +832,8 @@ if(WIN32 AND PY_VERSION VERSION_GREATER_EQUAL "3.11")
             VERSION="${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}"
             VPATH="..\\\\.."
             PYDEBUGEXT="$<$<CONFIG:Debug>:_d>"
-            PLATLIBDIR="DLLs"
-            PYTHONPATH="Lib\\\\lib-dynload"
+            PLATLIBDIR="${LIBDIR}"
+            PYTHONPATH="${_wide_char_modifier}${PYTHONPATH}"
         )
     set_property(
         SOURCE ${SRC_DIR}/PC/dl_nt.c

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -423,6 +423,25 @@ configure_file(
     ${PROJECT_BINARY_DIR}/CMakeFiles/config.c
     )
 
+if(WIN32 AND PY_VERSION VERSION_GREATER_EQUAL "3.11")
+set(config_inits "")
+set(minimal_builtin_extensions _codecs _collections _io _imp _sre _thread _tracemalloc _weakref errno faulthandler itertools time)
+if(WIN32)
+    list(APPEND minimal_builtin_extensions nt winreg)
+    set(config_inits "${config_inits}/* Define extern variables omitted from minimal builds */\n")
+    set(config_inits "${config_inits}void *PyWin_DLLhModule = NULL;\n\n")
+endif()
+set(config_entries "")
+foreach(ext IN LISTS minimal_builtin_extensions)
+    set(config_inits "${config_inits}extern ${init_return_type} ${init_prefix}${ext}(void);\n")
+    set(config_entries "${config_entries}    {\"${ext}\", ${init_prefix}${ext}},\n")
+endforeach()
+configure_file(
+    ${PROJECT_SOURCE_DIR}/cmake/config_${PY_VERSION_MAJOR}.c.in
+    ${PROJECT_BINARY_DIR}/CMakeFiles/config_minimal.c
+    )
+endif()
+
 # Collect libpython target libraries
 set(LIBPYTHON_TARGET_LIBRARIES
   ${builtin_link_libraries}
@@ -457,7 +476,7 @@ add_executable(_freeze_importlib
   # Introduced in Python 3.11
   $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Programs/_freeze_module.c>
   $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Modules/getpath_noop.c>
-  $<$<AND:$<BOOL:${WIN32}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>>:${SRC_DIR}/PC/config_minimal.c>
+  $<$<AND:$<BOOL:${WIN32}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>>:${PROJECT_BINARY_DIR}/CMakeFiles/config_minimal.c>
 
   ${LIBPYTHON_OMIT_FROZEN_SOURCES}
   )
@@ -704,7 +723,7 @@ if(PY_VERSION VERSION_GREATER_EQUAL "3.11")
 add_executable(_bootstrap_python
     ${SRC_DIR}/Programs/_bootstrap_python.c
     ${SRC_DIR}/Modules/getpath.c
-    $<$<BOOL:${WIN32}>:${SRC_DIR}/PC/config_minimal.c>
+    $<$<BOOL:${WIN32}>:${PROJECT_BINARY_DIR}/CMakeFiles/config_minimal.c>
     ${LIBPYTHON_OMIT_FROZEN_SOURCES}
     ${LIBPYTHON_FROZEN_SOURCES}
 )

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -3,15 +3,24 @@ add_definitions(-DPy_BUILD_CORE_BUILTIN)
 add_definitions(-DNDEBUG)
 
 set(MODULE_SOURCES # Equivalent to MODULE_OBJS in Makefile.pre
-    ${PROJECT_BINARY_DIR}/CMakeFiles/config.c
     ${SRC_DIR}/Modules/gcmodule.c
     ${SRC_DIR}/Modules/main.c
 )
+if(UNIX OR PY_VERSION VERSION_LESS "3.11")
+    list(APPEND MODULE_SOURCES
+        ${PROJECT_BINARY_DIR}/CMakeFiles/config.c
+    )
+endif()
 if(UNIX)
     list(APPEND MODULE_SOURCES
-        ${SRC_DIR}/Modules/getpath.c
+        # Starting with Python 3.11 "Modules/getpath.c" is deepfrozen and later appended to LIBPYTHON_SOURCES
+        $<$<VERSION_LESS:${PY_VERSION},3.11>:${SRC_DIR}/Modules/getpath.c>
     )
     set(PYTHONPATH "${EXTRA_PYTHONPATH}:lib-dynload:plat-${PY_PLATFORM}")
+    if(PY_VERSION VERSION_GREATER_EQUAL "3.11")
+        set(PYTHONPATH "${PYTHONPATH}:lib/python${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}")
+        set(PYTHONPATH "${PYTHONPATH}:lib/python${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}/lib-dynload")
+    endif()
     if(ENABLE_TKINTER)
         set(PYTHONPATH "${PYTHONPATH}:lib-tk")
     endif()
@@ -23,8 +32,12 @@ if(UNIX)
             VERSION="${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}"
             VPATH="."
             PYTHONPATH="${PYTHONPATH}"
+            PLATLIBDIR="${LIBDIR}" # Introduced in Python 3.11
       )
-elseif(WIN32)
+endif()
+
+# Removed in Python 3.11
+if(WIN32 AND PY_VERSION VERSION_LESS "3.11")
     list(APPEND MODULE_SOURCES
         ${SRC_DIR}/PC/getpathp.c
     )
@@ -99,6 +112,10 @@ set(PARSER_COMMON_SOURCES # Equivalent to POBJS in Makefile.pre
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.10>:${SRC_DIR}/Parser/peg_api.c>
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.10>:${SRC_DIR}/Parser/pegen.c>
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.10>:${SRC_DIR}/Parser/string_parser.c>
+
+    # Introduced in Python 3.11
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Parser/action_helpers.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Parser/pegen_errors.c>
 )
 
 set(OBJECT_COMMON_SOURCES # Equivalent to OBJECT_OBJS in Makefile.pre
@@ -178,10 +195,11 @@ if(UNIX AND HAVE_DLOPEN)
         SOURCE ${SRC_DIR}/Python/dynload_shlib.c
         PROPERTY COMPILE_DEFINITIONS
             SOABI="${SOABI}"
+            #MULTIARCH
         )
 elseif(WIN32)
     list(APPEND DYNLOAD_SOURCES
-        ${SRC_DIR}/PC/dl_nt.c
+        $<$<VERSION_LESS:${PY_VERSION},3.11>:${SRC_DIR}/PC/dl_nt.c>
         ${SRC_DIR}/Python/dynload_win.c
         )
     set(ms_dll_id "${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}")
@@ -193,6 +211,11 @@ elseif(WIN32)
         PROPERTY COMPILE_DEFINITIONS
             Py_ENABLE_SHARED
             MS_DLL_ID="${ms_dll_id}"
+        )
+    set_property(
+        SOURCE ${SRC_DIR}/Python/dynload_win.c
+        PROPERTY COMPILE_DEFINITIONS
+            "PY3_DLLNAME=\"python3$<$<CONFIG:Debug>:_d>\"" # Python 3.11
         )
 endif()
 
@@ -267,6 +290,11 @@ set(PYTHON_COMMON_SOURCES
 
     # Introduced in Python 3.10
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.10>:${SRC_DIR}/Python/suggestions.c>
+
+    # Introduced in Python 3.11
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Python/Python-tokenize.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Python/frame.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Python/specialize.c>
 )
 
 if(UNIX)
@@ -275,7 +303,8 @@ if(UNIX)
     )
 else()
     list(APPEND PYTHON_COMMON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
+        # Removed in Python 3.11
+        $<$<VERSION_LESS:${PY_VERSION},3.11>:${SRC_DIR}/Python/frozen.c>
     )
 endif()
 
@@ -285,9 +314,12 @@ if(UNIX OR MINGW)
         PROPERTY COMPILE_DEFINITIONS
             PLATFORM="${PY_PLATFORM}"
     )
+endif()
+if(UNIX OR MINGW OR PY_VERSION VERSION_GREATER_EQUAL "3.11")
     set_property(
         SOURCE ${SRC_DIR}/Python/sysmodule.c
         PROPERTY COMPILE_DEFINITIONS
+            VPATH="..\\\\.." # Python 3.11
             ABIFLAGS="${ABIFLAGS}"
         )
 endif()
@@ -410,6 +442,7 @@ if(WIN32)
       $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>:version> # Required by sysmodule
       $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.6>:shlwapi> # Required by PC/getpathp
       $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.9>:pathcch>
+      $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:bcrypt> # Required by bootstrap_hash
      )
 endif()
 
@@ -417,15 +450,28 @@ set(LIBPYTHON_FROZEN_SOURCES )
 
 # Build _freeze_importlib executable
 add_executable(_freeze_importlib
-  $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.3>:${SRC_DIR}/$<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>,Programs,Modules>/_freeze_importlib.c>
+
+  # Introduced in Python 3.3 and removed in Python 3.11
+  $<$<AND:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.3>,$<VERSION_LESS:${PY_VERSION},3.11>>:${SRC_DIR}/$<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.5>,Programs,Modules>/_freeze_importlib.c>
+
+  # Introduced in Python 3.11
+  $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Programs/_freeze_module.c>
+  $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Modules/getpath_noop.c>
+  $<$<AND:$<BOOL:${WIN32}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>>:${SRC_DIR}/PC/config_minimal.c>
+
   ${LIBPYTHON_OMIT_FROZEN_SOURCES}
   )
 target_link_libraries(_freeze_importlib ${LIBPYTHON_TARGET_LIBRARIES})
 if(builtin_compile_definitions_without_py_limited_api)
   target_compile_definitions(_freeze_importlib PUBLIC ${builtin_compile_definitions_without_py_limited_api})
 endif()
+target_compile_definitions(_freeze_importlib
+  PUBLIC
+    Py_NO_ENABLE_SHARED
+)
 
-# Freeze modules
+# Freeze modules for Python < 3.11
+if(PY_VERSION VERSION_LESS "3.11")
 set(LIBPYTHON_FROZEN_SOURCES
   ${SRC_DIR}/Python/importlib_external.h
   ${SRC_DIR}/Python/importlib.h
@@ -448,6 +494,7 @@ add_custom_command(
     ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
     ${SRC_DIR}/Lib/importlib/_bootstrap.py
 )
+
 if(PY_VERSION VERSION_GREATER_EQUAL "3.8")
   add_custom_command(
     OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
@@ -461,10 +508,258 @@ if(PY_VERSION VERSION_GREATER_EQUAL "3.8")
     APPEND
   )
 endif()
+endif()
+
+# Freeze modules for Python >= 3.11
+if(PY_VERSION VERSION_GREATER_EQUAL "3.11")
+
+set(LIBPYTHON_FROZEN_SOURCES
+  ${SRC_DIR}/Python/frozen_modules/importlib._bootstrap.h
+  ${SRC_DIR}/Python/frozen_modules/importlib._bootstrap_external.h
+  ${SRC_DIR}/Python/frozen_modules/zipimport.h
+  ${SRC_DIR}/Python/frozen_modules/abc.h
+  ${SRC_DIR}/Python/frozen_modules/codecs.h
+  ${SRC_DIR}/Python/frozen_modules/io.h
+  ${SRC_DIR}/Python/frozen_modules/_collections_abc.h
+  ${SRC_DIR}/Python/frozen_modules/_sitebuiltins.h
+  ${SRC_DIR}/Python/frozen_modules/genericpath.h
+  ${SRC_DIR}/Python/frozen_modules/ntpath.h
+  ${SRC_DIR}/Python/frozen_modules/posixpath.h
+  ${SRC_DIR}/Python/frozen_modules/os.h
+  ${SRC_DIR}/Python/frozen_modules/site.h
+  ${SRC_DIR}/Python/frozen_modules/stat.h
+  ${SRC_DIR}/Python/frozen_modules/importlib.util.h
+  ${SRC_DIR}/Python/frozen_modules/importlib.machinery.h
+  ${SRC_DIR}/Python/frozen_modules/runpy.h
+  ${SRC_DIR}/Python/frozen_modules/__hello__.h
+  ${SRC_DIR}/Python/frozen_modules/__phello__.h
+  ${SRC_DIR}/Python/frozen_modules/__phello__.ham.h
+  ${SRC_DIR}/Python/frozen_modules/__phello__.ham.eggs.h
+  ${SRC_DIR}/Python/frozen_modules/__phello__.spam.h
+  ${SRC_DIR}/Python/frozen_modules/frozen_only.h
+  ${SRC_DIR}/Python/frozen_modules/getpath.h
+)
+add_custom_command(
+  OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      importlib._bootstrap
+      ${SRC_DIR}/Lib/importlib/_bootstrap.py
+      ${SRC_DIR}/Python/frozen_modules/importlib._bootstrap.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      importlib._bootstrap_external
+      ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
+      ${SRC_DIR}/Python/frozen_modules/importlib._bootstrap_external.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      zipimport
+      ${SRC_DIR}/Lib/zipimport.py
+      ${SRC_DIR}/Python/frozen_modules/zipimport.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      abc
+      ${SRC_DIR}/Lib/abc.py
+      ${SRC_DIR}/Python/frozen_modules/abc.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      codecs
+      ${SRC_DIR}/Lib/codecs.py
+      ${SRC_DIR}/Python/frozen_modules/codecs.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      io
+      ${SRC_DIR}/Lib/io.py
+      ${SRC_DIR}/Python/frozen_modules/io.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      _collections_abc
+      ${SRC_DIR}/Lib/_collections_abc.py
+      ${SRC_DIR}/Python/frozen_modules/_collections_abc.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      _sitebuiltins
+      ${SRC_DIR}/Lib/_sitebuiltins.py
+      ${SRC_DIR}/Python/frozen_modules/_sitebuiltins.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      genericpath
+      ${SRC_DIR}/Lib/genericpath.py
+      ${SRC_DIR}/Python/frozen_modules/genericpath.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      ntpath
+      ${SRC_DIR}/Lib/ntpath.py
+      ${SRC_DIR}/Python/frozen_modules/ntpath.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      posixpath
+      ${SRC_DIR}/Lib/posixpath.py
+      ${SRC_DIR}/Python/frozen_modules/posixpath.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      os
+      ${SRC_DIR}/Lib/os.py
+      ${SRC_DIR}/Python/frozen_modules/os.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      site
+      ${SRC_DIR}/Lib/site.py
+      ${SRC_DIR}/Python/frozen_modules/site.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      stat
+      ${SRC_DIR}/Lib/stat.py
+      ${SRC_DIR}/Python/frozen_modules/stat.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      importlib.util
+      ${SRC_DIR}/Lib/importlib/util.py
+      ${SRC_DIR}/Python/frozen_modules/importlib.util.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      importlib.machinery
+      ${SRC_DIR}/Lib/importlib/machinery.py
+      ${SRC_DIR}/Python/frozen_modules/importlib.machinery.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      runpy
+      ${SRC_DIR}/Lib/runpy.py
+      ${SRC_DIR}/Python/frozen_modules/runpy.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      __hello__
+      ${SRC_DIR}/Lib/__hello__.py
+      ${SRC_DIR}/Python/frozen_modules/__hello__.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      __phello__
+      ${SRC_DIR}/Lib/__phello__/__init__.py
+      ${SRC_DIR}/Python/frozen_modules/__phello__.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      __phello__.ham
+      ${SRC_DIR}/Lib/__phello__/ham/__init__.py
+      ${SRC_DIR}/Python/frozen_modules/__phello__.ham.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      __phello__.ham.eggs
+      ${SRC_DIR}/Lib/__phello__/ham/eggs.py
+      ${SRC_DIR}/Python/frozen_modules/__phello__.ham.eggs.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      __phello__.spam
+      ${SRC_DIR}/Lib/__phello__/spam.py
+      ${SRC_DIR}/Python/frozen_modules/__phello__.spam.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      frozen_only
+      ${SRC_DIR}/Tools/freeze/flag.py
+      ${SRC_DIR}/Python/frozen_modules/frozen_only.h
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      getpath
+      ${SRC_DIR}/Modules/getpath.py
+      ${SRC_DIR}/Python/frozen_modules/getpath.h
+  DEPENDS
+      _freeze_importlib
+      ${SRC_DIR}/Lib/importlib/_bootstrap.py
+      ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
+      ${SRC_DIR}/Lib/zipimport.py
+      ${SRC_DIR}/Lib/abc.py
+      ${SRC_DIR}/Lib/codecs.py
+      ${SRC_DIR}/Lib/io.py
+      ${SRC_DIR}/Lib/_collections_abc.py
+      ${SRC_DIR}/Lib/_sitebuiltins.py
+      ${SRC_DIR}/Lib/genericpath.py
+      ${SRC_DIR}/Lib/ntpath.py
+      ${SRC_DIR}/Lib/posixpath.py
+      ${SRC_DIR}/Lib/os.py
+      ${SRC_DIR}/Lib/site.py
+      ${SRC_DIR}/Lib/stat.py
+      ${SRC_DIR}/Lib/importlib/util.py
+      ${SRC_DIR}/Lib/importlib/machinery.py
+      ${SRC_DIR}/Lib/runpy.py
+      ${SRC_DIR}/Lib/__hello__.py
+      ${SRC_DIR}/Lib/__phello__/__init__.py
+      ${SRC_DIR}/Lib/__phello__/ham/__init__.py
+      ${SRC_DIR}/Lib/__phello__/ham/eggs.py
+      ${SRC_DIR}/Lib/__phello__/spam.py
+      ${SRC_DIR}/Tools/freeze/flag.py
+      ${SRC_DIR}/Modules/getpath.py
+  )
+endif()
 
 # This is a convenience target allowing to regenerate
 # the frozen sources.
-add_custom_target(freeze_modules DEPENDS ${LIBPYTHON_FROZEN_SOURCES})
+add_custom_target(freeze_modules DEPENDS
+    ${LIBPYTHON_FROZEN_SOURCES}
+)
+
+set(LIBPYTHON_DEEPFREEZE_SOURCES )
+
+if(PY_VERSION VERSION_GREATER_EQUAL "3.11")
+
+# Build _bootstrap_python executable
+add_executable(_bootstrap_python
+    ${SRC_DIR}/Programs/_bootstrap_python.c
+    ${SRC_DIR}/Modules/getpath.c
+    $<$<BOOL:${WIN32}>:${SRC_DIR}/PC/config_minimal.c>
+    ${LIBPYTHON_OMIT_FROZEN_SOURCES}
+    ${LIBPYTHON_FROZEN_SOURCES}
+)
+target_link_libraries(_bootstrap_python ${LIBPYTHON_TARGET_LIBRARIES})
+target_compile_definitions(_bootstrap_python
+    PUBLIC
+        Py_NO_ENABLE_SHARED
+)
+
+list(APPEND LIBPYTHON_DEEPFREEZE_SOURCES
+    ${SRC_DIR}/Python/deepfreeze/deepfreeze.c
+)
+
+set(DEEPFREEZE_PY ${SRC_DIR}/Tools/scripts/deepfreeze.py)
+
+add_custom_command(
+  OUTPUT ${LIBPYTHON_DEEPFREEZE_SOURCES}
+  COMMAND
+    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_bootstrap_python>
+      ${DEEPFREEZE_PY}
+        "${SRC_DIR}/Python/frozen_modules/importlib._bootstrap.h:importlib._bootstrap"
+        "${SRC_DIR}/Python/frozen_modules/importlib._bootstrap_external.h:importlib._bootstrap_external"
+        "${SRC_DIR}/Python/frozen_modules/zipimport.h:zipimport"
+        "${SRC_DIR}/Python/frozen_modules/abc.h:abc"
+        "${SRC_DIR}/Python/frozen_modules/codecs.h:codecs"
+        "${SRC_DIR}/Python/frozen_modules/io.h:io"
+        "${SRC_DIR}/Python/frozen_modules/_collections_abc.h:_collections_abc"
+        "${SRC_DIR}/Python/frozen_modules/_sitebuiltins.h:_sitebuiltins"
+        "${SRC_DIR}/Python/frozen_modules/genericpath.h:genericpath"
+        "${SRC_DIR}/Python/frozen_modules/ntpath.h:ntpath"
+        "${SRC_DIR}/Python/frozen_modules/posixpath.h:posixpath"
+        "${SRC_DIR}/Python/frozen_modules/os.h:os"
+        "${SRC_DIR}/Python/frozen_modules/site.h:site"
+        "${SRC_DIR}/Python/frozen_modules/stat.h:stat"
+        "${SRC_DIR}/Python/frozen_modules/importlib.util.h:importlib.util"
+        "${SRC_DIR}/Python/frozen_modules/importlib.machinery.h:importlib.machinery"
+        "${SRC_DIR}/Python/frozen_modules/runpy.h:runpy"
+        "${SRC_DIR}/Python/frozen_modules/__hello__.h:__hello__"
+        "${SRC_DIR}/Python/frozen_modules/__phello__.h:__phello__"
+        "${SRC_DIR}/Python/frozen_modules/__phello__.ham.h:__phello__.ham"
+        "${SRC_DIR}/Python/frozen_modules/__phello__.ham.eggs.h:__phello__.ham.eggs"
+        "${SRC_DIR}/Python/frozen_modules/__phello__.spam.h:__phello__.spam"
+        "${SRC_DIR}/Python/frozen_modules/frozen_only.h:frozen_only"
+      "-o" "${LIBPYTHON_DEEPFREEZE_SOURCES}"
+  DEPENDS
+    ${DEEPFREEZE_PY}
+    ${LIBPYTHON_FROZEN_SOURCES}
+)
+
+# This is a convenience target allowing to regenerate
+# the deepfreeze sources.
+add_custom_target(deepfreeze_modules DEPENDS
+    ${LIBPYTHON_DEEPFREEZE_SOURCES}
+)
+endif()
 
 if(PY_VERSION VERSION_LESS "3.8")
 # Build pgen executable
@@ -495,11 +790,33 @@ endif()
 set(LIBPYTHON_SOURCES
     ${LIBPYTHON_OMIT_FROZEN_SOURCES}
     ${LIBPYTHON_FROZEN_SOURCES}
+    ${LIBPYTHON_DEEPFREEZE_SOURCES}
+    $<$<OR:$<BOOL:${UNIX}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>>:${SRC_DIR}/Python/frozen.c>
+
+    # Introduced in Python 3.11
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Modules/getpath.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Modules/_typingmodule.c>
+    $<$<AND:$<BOOL:${WIN32}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>>:${PROJECT_BINARY_DIR}/CMakeFiles/config.c>
+    $<$<AND:$<BOOL:${WIN32}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>>:${SRC_DIR}/PC/dl_nt.c>
 )
-if(UNIX)
-    list(APPEND LIBPYTHON_SOURCES
-        ${SRC_DIR}/Python/frozen.c
-    )
+if(WIN32 AND PY_VERSION VERSION_GREATER_EQUAL "3.11")
+    set_property(
+        SOURCE ${SRC_DIR}/Modules/getpath.c
+        PROPERTY COMPILE_DEFINITIONS
+            PREFIX=NULL
+            EXEC_PREFIX=NULL
+            VERSION="${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}"
+            VPATH="..\\\\.."
+            PYDEBUGEXT="$<$<CONFIG:Debug>:_d>"
+            PLATLIBDIR="DLLs"
+            PYTHONPATH="Lib\\\\lib-dynload"
+        )
+    set_property(
+        SOURCE ${SRC_DIR}/PC/dl_nt.c
+        PROPERTY COMPILE_DEFINITIONS
+            Py_ENABLE_SHARED
+            MS_DLL_ID="${ms_dll_id}"
+        )
 endif()
 
 # Build python libraries

--- a/patches/3.11/0001-_bootstrap_python-Fix-execution-on-windows-disabling.patch
+++ b/patches/3.11/0001-_bootstrap_python-Fix-execution-on-windows-disabling.patch
@@ -1,0 +1,51 @@
+From 50a9d90c04eb672d35d516b32c802760a0736a23 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Tue, 13 May 2025 20:36:35 -0400
+Subject: [PATCH] _bootstrap_python: Fix execution on windows disabling site
+ import
+
+This workaround the lack of `sys.winver` attribute addressing the following
+error:
+
+```
+ Generating C:/path/to/Python-3.11.12/Python/deepfreeze/deepfreeze.c
+CUSTOMBUILD : Fatal Python error : init_import_site: Failed to import the site module [C:\path\to\pycbs-3.11-build\CMakeBuild\libpython\libpython-shared.vcxproj]
+  Python runtime state: initialized
+  Traceback (most recent call last):
+    File "C:\path\to\pycbs-3.11-build\Lib\site.py", line 626, in <module>
+      main()
+    File "C:\path\to\pycbs-3.11-build\Lib\site.py", line 612, in main
+      known_paths = addusersitepackages(known_paths)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "C:\path\to\pycbs-3.11-build\Lib\site.py", line 350, in addusersitepackages
+      user_site = getusersitepackages()
+                  ^^^^^^^^^^^^^^^^^^^^^
+    File "C:\path\to\pycbs-3.11-build\Lib\site.py", line 337, in getusersitepackages
+      USER_SITE = _get_path(userbase)
+                  ^^^^^^^^^^^^^^^^^^^
+    File "C:\path\to\pycbs-3.11-build\Lib\site.py", line 302, in _get_path
+      ver_nodot = sys.winver.replace('.', '')
+                  ^^^^^^^^^^
+  AttributeError: module 'sys' has no attribute 'winver'
+```
+---
+ Programs/_bootstrap_python.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Programs/_bootstrap_python.c b/Programs/_bootstrap_python.c
+index 6ecbf0c72b5..136c187758d 100644
+--- a/Programs/_bootstrap_python.c
++++ b/Programs/_bootstrap_python.c
+@@ -72,6 +72,9 @@ main(int argc, char **argv)
+     // add current script dir to sys.path
+     config.isolated = 0;
+     config.safe_path = 0;
++#ifdef MS_WINDOWS
++    config.site_import = 0;
++#endif
+ 
+ #ifdef MS_WINDOWS
+     status = PyConfig_SetArgv(&config, argc, argv);
+-- 
+2.48.1
+

--- a/patches/3.11/README.rst
+++ b/patches/3.11/README.rst
@@ -1,0 +1,1 @@
+* ``0001-_bootstrap_python-Fix-execution-on-windows-disabling.patch``: _bootstrap_python: Fix execution on windows disabling site import.


### PR DESCRIPTION
* Add checksums for Python 3.11.0 to 3.11.12

* Set default python version to 3.11.12

* Switch from `c99` to `c11`

* Add convenience target `deepfreeze_modules` for regenerating download the deepfreeze sources

* Check that TCL is at least 8.5.12

dbm extension:

* Add support for `GDBM_COMPAT` introducing `NDBM_USE` variable set to either
  `NDBM` or `GDBM_COMPAT`. See python/cpython@0a9f69539be ("bpo-45747: Detect gdbm/dbm dependencies in configure (GH-29467)", 2021-11-10)

Updated pyconfig.h.in

* Add the following for which there was already a configure check.
  - Headers:
    - `HAVE_BZLIB_H`
    - `HAVE_DB_H`
    - `HAVE_GDBM_DASH_NDBM_H`
    - `HAVE_GDBM_H`
    - `HAVE_GDBM_NDBM_H`
    - `HAVE_LZMA_H`
    - `HAVE_NDBM_H`
    - `HAVE_NETDB_H`
    - `HAVE_NETINET_IN_H`
    - `HAVE_RPC_RPC_H`
    - `HAVE_ZLIB_H`
  - Library:
    - `HAVE_LIBDB`
    - `HAVE_LIBGDBM_COMPAT`
    - `HAVE_LIBNDBM`
    - `HAVE_LIBSQLITE3`

Updated pyconfig.h.in and configure checks:

* Add options:
  - `WITH_FREELISTS` set to 1 if Python 3.11 and 0 otherwise

* Add header checks:
  - `HAVE_LINUX_LIMITS_H`
  - `HAVE_LINUX_SOUNDCARD_H`
  - `HAVE_NETCAN_CAN_H`
  - `HAVE_SETJMP_H`
  - `HAVE_SYS_SOUNDCARD_H`
  - `HAVE_SYSLOG_H`
  - `HAVE_UTMP_H`

* Add symbol checks:
  - `HAVE_ACCEPT`
  - `HAVE_BIND`
  - `HAVE_CHMOD`
  - `HAVE_CLOCK_NANOSLEEP`
  - `HAVE_CONNECT`
  - `HAVE_DUP`
  - `HAVE_FORK1`
  - `HAVE_GETEGID`
  - `HAVE_GETEUID`
  - `HAVE_GETGID`
  - `HAVE_GETGRGID`
  - `HAVE_GETHOSTBYADDR`
  - `HAVE_GETHOSTNAME`
  - `HAVE_GETPPID`
  - `HAVE_GETPROTOBYNAME`
  - `HAVE_GETPWUID`
  - `HAVE_GETRUSAGE`
  - `HAVE_GETSERVBYNAME`
  - `HAVE_GETSERVBYPORT`
  - `HAVE_GETSOCKNAME`
  - `HAVE_GETUID`
  - `HAVE_INET_NTOA`
  - `HAVE_LISTEN`
  - `HAVE_LOGIN_TTY`
  - `HAVE_NANOSLEEP`
  - `HAVE_OPENDIR`
  - `HAVE_PIPE`
  - `HAVE_RECVFROM`
  - `HAVE_RL_COMPDISP_FUNC_T`
  - `HAVE_SENDTO`
  - `HAVE_SETSOCKOPT`
  - `HAVE_SHUTDOWN`
  - `HAVE_SOCKET`
  - `HAVE_SYSTEM`
  - `HAVE_TTYNAME`
  - `HAVE_UMASK`
  - `HAVE_WAIT`

Testing:

* Command line option "-l/--findleaks" of `regrtest` is deprecated since Python 3.7 and removed in Python 3.11. It is superseded by `--fail-env-changed`.

----------

Update `pyconfig.h.in` adding the following WASI related defines that will require additional work: `HAVE_PTHREAD_STUBS`, `_WASI_EMULATED_GETPID`, `_WASI_EMULATED_PROCESS_CLOCKS`, `_WASI_EMULATED_SIGNAL`:
* https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/issues/394

----------

Working toward addressing:
* #350