### PR TITLE
cmake: Fix generation of ".pyd" module removing extra dot

### DIFF
--- a/cmake/Extensions.cmake
+++ b/cmake/Extensions.cmake
@@ -208,7 +208,7 @@ function(add_python_extension name)
             ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${ARCHIVEDIR}
             LIBRARY_OUTPUT_DIRECTORY ${EXTENSION_BUILD_DIR}
             RUNTIME_OUTPUT_DIRECTORY ${EXTENSION_BUILD_DIR}
-            OUTPUT_NAME "${name}$<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.8>:.${SOABI}>"
+            OUTPUT_NAME "${name}$<$<AND:$<BOOL:${UNIX}>,$<VERSION_GREATER_EQUAL:${PY_VERSION},3.8>>:.${SOABI}>"
             PREFIX ""
         )
         set_target_properties(${target_name} PROPERTIES


### PR DESCRIPTION
Fix a regression introduced in 3c74c4b ("cmake: Starting with Python3.8, append SOABI to extension shared library name", 2025-05-09) ensuring the library name is "extension_name.pyd" instead of "extension_name..pyd"

Related pull requests:
* https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/388