### PR TITLE
Add support for building Python 3.12x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,17 @@ jobs:
 workflows:
     build-and-test:
       jobs:
+        # 3.12.10
+        - build-test-python:
+            name: python-3.12.10-x64
+            python_version: 3.12.10
+            python_arch: x64
+
+        - build-test-python:
+            name: python-3.12.10-x86
+            python_version: 3.12.10
+            python_arch: x86
+
         # 3.11.12
         - build-test-python:
             name: python-3.11.12-x64
@@ -155,6 +166,13 @@ workflows:
 
     build-and-test-win:
       jobs:
+        # 3.12.10
+        - build-test-python-win:
+            name: python-3.12.10-win-x64
+            python_version: 3.12.10
+            python_arch: x64
+            generator: "Visual Studio 16 2019"
+
         # 3.11.12
         - build-test-python-win:
             name: python-3.11.12-win-x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [macos-latest]
-        python-version: [3.7.17, 3.8.20, 3.9.22, 3.10.17, 3.11.12]
+        python-version: [3.7.17, 3.8.20, 3.9.22, 3.10.17, 3.11.12, 3.12.10]
         include:
           - runs-on: macos-latest
             c-compiler: "clang"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,6 +635,14 @@ if(BUILD_WININST)
     add_subdirectory(cmake/PC/bdist_wininst CMakeBuild/bdist_wininst)
 endif()
 
+# Ensure the "_testcapi" extension introduced in Python 3.12 can find
+# find "Python3.lib" as it is specified in "PC/pyconfig." using
+# `pragma comment(lib,"python3.lib")`.
+if(WIN32 AND TARGET extension_testcapi)
+    set(libpython_output_dir "${PROJECT_BINARY_DIR}/CMakeBuild/libpython/$<CONFIG>")
+    target_link_directories(extension_testcapi PRIVATE ${libpython_output_dir})
+endif()
+
 # Add target to run "Argument Clinic" over all source files
 add_custom_target(clinic
     COMMAND python ${SRC_DIR}/Tools/clinic/clinic.py --make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20.6)
 
-set(PYTHON_VERSION "3.11.12" CACHE STRING "The version of Python to build.")
+set(PYTHON_VERSION "3.12.10" CACHE STRING "The version of Python to build.")
 
 string(REPLACE "." ";" VERSION_LIST ${PYTHON_VERSION})
 list(GET VERSION_LIST 0 PY_VERSION_MAJOR)
@@ -311,6 +311,18 @@ set(_download_3.11.9_md5 "bfd4d3bfeac4216ce35d7a503bf02d5c")
 set(_download_3.11.10_md5 "35c36069a43dd57a7e9915deba0f864e")
 set(_download_3.11.11_md5 "9a5b43fcc06810b8ae924b0a080e6569")
 set(_download_3.11.12_md5 "b8bb496014f05f5be180fab74810f40b")
+# 3.12.x
+set(_download_3.12.0_md5 "d6eda3e1399cef5dfde7c4f319b0596c")
+set(_download_3.12.1_md5 "51c5c22dcbc698483734dff5c8028606")
+set(_download_3.12.2_md5 "4e64a004f8ad9af1a75607cfd0d5a8c8")
+set(_download_3.12.3_md5 "3c5498a34d5226c9b746b1199f0bf2d9")
+set(_download_3.12.4_md5 "ead819dab6d165937138daa9e51ccb54")
+set(_download_3.12.5_md5 "d23d56b51d36a9d51b2b13d30c849d00")
+set(_download_3.12.6_md5 "c2f1dd5c8807ee50b778684b7958ee28")
+set(_download_3.12.7_md5 "5d0c0e4c6a022a87165a9addcd869109")
+set(_download_3.12.8_md5 "304473cf367fa65e450edf4b06b55fcc")
+set(_download_3.12.9_md5 "ce613c72fa9b32fb4f109762d61b249b")
+set(_download_3.12.10_md5 "35c03f014408e26e2b06d576c19cac54")
 
 set(_extracted_dir "Python-${PY_VERSION}")
 

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ options on the commandline with `-DOPTION=VALUE`, or use the "ccmake" gui.
 
 ::
 
-  PYTHON_VERSION=major.minor.patch (defaults to 3.11.12)
+  PYTHON_VERSION=major.minor.patch (defaults to 3.12.10)
     The version of Python to build.
 
   PYTHON_APPLY_PATCHES=ON|OFF (defaults to ON)

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -853,7 +853,6 @@ check_type_size(ssize_t HAVE_SSIZE_T)
 check_type_size(time_t SIZEOF_TIME_T)
 check_type_size(uintptr_t SIZEOF_UINTPTR_T)
 set(HAVE_UINTPTR_T ${SIZEOF_UINTPTR_T})
-check_type_size(max_align_t ALIGNOF_MAX_ALIGN_T) # Python 3.12
 check_type_size("void *" SIZEOF_VOID_P)
 check_type_size(wchar_t SIZEOF_WCHAR_T)
 check_type_size(_Bool SIZEOF__BOOL)
@@ -892,6 +891,7 @@ endfunction()
 
 _check_type_alignof(long) # Python 3.10
 _check_type_alignof(size_t) # Python 3.10
+_check_type_alignof(max_align_t) # Python 3.12
 
 set(HAVE_C99_BOOL ${SIZEOF__BOOL})
 

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -39,6 +39,13 @@ if(USE_SYSTEM_Curses)
       message(STATUS "${_msg} - not found")
     endif()
 
+    # Python 3.12
+    if(Curses_FOUND)
+      set(HAVE_NCURSESW 1)
+    else()
+      set(HAVE_NCURSESW 0)
+    endif()
+
     if(NOT Curses_FOUND)
       message(STATUS "")
       set(_msg "Looking for curses without Unicode support")
@@ -80,6 +87,7 @@ if(USE_SYSTEM_LibFFI)
     message(STATUS "LibFFI_INCLUDE_DIR=${LibFFI_INCLUDE_DIR}")
     message(STATUS "LibFFI_LIBRARY=${LibFFI_LIBRARY}")
 endif()
+set(HAVE_LIBFFI ${LibFFI_LIBRARY}) # Python 3.12
 
 if(USE_SYSTEM_LIBMPDEC)
     find_library(LIBMPDEC_LIBRARY NAMES mpdec libmpdec)
@@ -195,9 +203,11 @@ set(HAVE_LZMA_H ${LZMA_INCLUDE_PATH}) # Python 3.11
 if(USE_SYSTEM_READLINE)
     if(USE_LIBEDIT)
         find_path(READLINE_INCLUDE_PATH editline/readline.h)
+        set(HAVE_EDITLINE_READLINE_H ${READLINE_INCLUDE_PATH}) # Python 3.12
         find_library(READLINE_LIBRARY edit)
     else()
         find_path(READLINE_INCLUDE_PATH readline/readline.h)
+        set(HAVE_READLINE_READLINE_H ${READLINE_INCLUDE_PATH}) # Python 3.12
         find_library(READLINE_LIBRARY readline)
     endif()
 endif()
@@ -387,6 +397,7 @@ check_include_files(minix/config.h HAVE_MINIX_CONFIG_H)
 check_include_files(ncurses.h HAVE_NCURSES_H)
 check_include_files(ncurses/panel.h HAVE_NCURSES_PANEL_H)
 check_include_files(netdb.h HAVE_NETDB_H)
+check_include_files(net/ethernet.h HAVE_NET_ETHERNET_H) # Python 3.12
 check_include_files(netinet/in.h HAVE_NETINET_IN_H)
 check_include_files(netpacket/packet.h HAVE_NETPACKET_PACKET_H)
 check_include_files(panel.h HAVE_PANEL_H)
@@ -406,6 +417,7 @@ check_include_files(shadow.h HAVE_SHADOW_H)
 check_include_files(signal.h HAVE_SIGNAL_H)
 check_include_files(spawn.h HAVE_SPAWN_H)
 check_include_files(stdint.h HAVE_STDINT_H)   # libffi and cpython
+check_include_files(stdio.h HAVE_STDIO_H) # Python 3.12
 check_include_files(stdlib.h HAVE_STDLIB_H)   # libffi and cpython
 check_include_files(strings.h HAVE_STRINGS_H) # libffi and cpython
 check_include_files(string.h HAVE_STRING_H)   # libffi and cpython
@@ -428,6 +440,7 @@ set(MAJOR_IN_MKDEV ${HAVE_SYS_MKDEV_H})
 check_include_files(sys/mman.h HAVE_SYS_MMAN_H) # libffi and cpython
 check_include_files(sys/modem.h HAVE_SYS_MODEM_H)
 check_include_files(sys/param.h HAVE_SYS_PARAM_H)
+check_include_files(sys/pidfd.h HAVE_SYS_PIDFD_H) # Python 3.12
 check_include_files(sys/poll.h HAVE_SYS_POLL_H)
 check_include_files(sys/random.h HAVE_SYS_RANDOM_H)
 check_include_files(sys/resource.h HAVE_SYS_RESOURCE_H)
@@ -455,6 +468,7 @@ check_include_files(stdarg.h HAVE_STDARG_PROTOTYPES)
 
 check_include_files(endian.h HAVE_ENDIAN_H)
 check_include_files(sched.h HAVE_SCHED_H)
+check_include_files(linux/fs.h HAVE_LINUX_FS_H) # Python 3.12
 check_include_files(linux/limits.h HAVE_LINUX_LIMITS_H) # Python 3.11
 check_include_files(linux/memfd.h HAVE_LINUX_MEMFD_H)
 check_include_files(linux/random.h HAVE_LINUX_RANDOM_H)
@@ -839,6 +853,7 @@ check_type_size(ssize_t HAVE_SSIZE_T)
 check_type_size(time_t SIZEOF_TIME_T)
 check_type_size(uintptr_t SIZEOF_UINTPTR_T)
 set(HAVE_UINTPTR_T ${SIZEOF_UINTPTR_T})
+check_type_size(max_align_t ALIGNOF_MAX_ALIGN_T) # Python 3.12
 check_type_size("void *" SIZEOF_VOID_P)
 check_type_size(wchar_t SIZEOF_WCHAR_T)
 check_type_size(_Bool SIZEOF__BOOL)
@@ -920,6 +935,7 @@ add_cond(CFG_HEADERS HAVE_SYS_SYSMACROS_H sys/sysmacros.h)
 add_cond(CFG_HEADERS HAVE_SYS_TYPES_H sys/types.h)
 add_cond(CFG_HEADERS HAVE_SYS_TIME_H sys/time.h)
 add_cond(CFG_HEADERS HAVE_SYS_FILE_H sys/file.h)
+add_cond(CFG_HEADERS HAVE_SYS_PIDFD_H sys/pidfd.h)
 add_cond(CFG_HEADERS HAVE_SYS_POLL_H sys/poll.h)
 add_cond(CFG_HEADERS HAVE_SYS_STATVFS_H sys/statvfs.h)
 add_cond(CFG_HEADERS HAVE_SYS_STAT_H sys/stat.h)
@@ -941,6 +957,7 @@ add_cond(CFG_HEADERS HAVE_FCNTL_H fcntl.h)
 add_cond(CFG_HEADERS HAVE_PTY_H pty.h)
 add_cond(CFG_HEADERS HAVE_SIGNAL_H signal.h)
 add_cond(CFG_HEADERS HAVE_STDINT_H stdint.h)
+add_cond(CFG_HEADERS HAVE_STDIO_H stdio.h)
 add_cond(CFG_HEADERS HAVE_STDLIB_H stdlib.h)
 add_cond(CFG_HEADERS HAVE_STRING_H string.h)
 add_cond(CFG_HEADERS HAVE_UTIL_H util.h)
@@ -1113,6 +1130,7 @@ check_symbol_exists(tmpnam       "${CFG_HEADERS}" HAVE_TMPNAM)
 check_symbol_exists(tmpnam_r     "${CFG_HEADERS}" HAVE_TMPNAM_R)
 check_symbol_exists(truncate     "${CFG_HEADERS}" HAVE_TRUNCATE)
 check_symbol_exists(ttyname      "${CFG_HEADERS}" HAVE_TTYNAME) # Python 3.11
+check_symbol_exists(ttyname_r    "${CFG_HEADERS}" HAVE_TTYNAME_R) # Python 3.12
 check_symbol_exists(umask        "${CFG_HEADERS}" HAVE_UMASK) # Python 3.11
 check_symbol_exists(uname        "${CFG_HEADERS}" HAVE_UNAME)
 check_symbol_exists(unsetenv     "${CFG_HEADERS}" HAVE_UNSETENV)
@@ -1214,6 +1232,10 @@ check_symbol_exists(wcsftime               "${CFG_HEADERS}" HAVE_WCSFTIME)
 check_symbol_exists(wcsxfrm                "${CFG_HEADERS}" HAVE_WCSXFRM)
 check_symbol_exists(wmemcmp                "${CFG_HEADERS}" HAVE_WMEMCMP)
 check_symbol_exists(writev                 "${CFG_HEADERS}" HAVE_WRITEV)
+
+# check for namespace functions
+check_symbol_exists(setns                  "${CFG_HEADERS}" HAVE_SETNS) # Python 3.12
+check_symbol_exists(unshare                "${CFG_HEADERS}" HAVE_UNSHARE) # Python 3.12
 
 check_struct_has_member("struct stat" st_mtim.tv_nsec "${CFG_HEADERS}" HAVE_STAT_TV_NSEC)
 check_struct_has_member("struct stat" st_mtimespec.tv_nsec "${CFG_HEADERS}"    HAVE_STAT_TV_NSEC2)
@@ -1355,6 +1377,15 @@ python_platform_test(
   ${check_src}
   DIRECT
   )
+
+# Python 3.12
+cmake_push_check_state()
+add_cond(CMAKE_REQUIRED_LIBRARIES HAVE_LIBFFI ${LibFFI_LIBRARY})
+check_symbol_exists(ffi_call              "ffi.h" HAVE_FFI_CALL)
+check_symbol_exists(ffi_closure_alloc     "ffi.h" HAVE_FFI_CLOSURE_ALLOC)
+check_symbol_exists(ffi_prep_cif_var      "ffi.h" HAVE_FFI_PREP_CIF_VAR)
+check_symbol_exists(ffi_prep_closure_loc  "ffi.h" HAVE_FFI_PREP_CLOSURE_LOC)
+cmake_pop_check_state()
 
 # libffi specific: Cannot use PROT_EXEC on this target, so, we revert to alternative means
 # XXX In autoconf system, it was set to true if target matches *arm*-apple-darwin*
@@ -1998,6 +2029,7 @@ endif()
 cmake_push_check_state()
 set(CFG_HEADERS_SAVE ${CFG_HEADERS})
 add_cond(CFG_HEADERS HAVE_NETDB_H netdb.h)
+add_cond(CFG_HEADERS HAVE_NET_ETHERNET_H net/ethernet.h)
 add_cond(CFG_HEADERS HAVE_NETINET_IN_H netinet/in.h)
 add_cond(CFG_HEADERS HAVE_ARPA_INET_H arpa/inet.h)
 

--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -20,6 +20,9 @@
 /* The normal alignment of `long', in bytes. [Python 3.10] */
 #cmakedefine ALIGNOF_LONG @SIZEOF_LONG@
 
+/* The normal alignment of `max_align_t', in bytes. [Python 3.12] */
+#cmakedefine ALIGNOF_MAX_ALIGN_T @ALIGNOF_MAX_ALIGN_T@
+
 /* The normal alignment of `size_t', in bytes. [Python 3.10] */
 #cmakedefine ALIGNOF_SIZE_T @SIZEOF_SIZE_T@
 
@@ -129,7 +132,7 @@
 /* Define if `unsetenv` does not return an int. */
 #cmakedefine HAVE_BROKEN_UNSETENV 1
 
-/* Has builtin atomics [Python 3] */
+/* Has builtin __atomic_load_n() and __atomic_store_n() functions [Python 3] */
 #cmakedefine HAVE_BUILTIN_ATOMIC 1
 
 /* Define this if you have the type _Bool. [Python <= 3.5] */
@@ -328,6 +331,9 @@
 /* Defined when any dynamic module loading is enabled. */
 #cmakedefine HAVE_DYNAMIC_LOADING 1
 
+/* Define to 1 if you have the <editline/readline.h> header file. [Python 3.12] */
+#cmakedefine HAVE_EDITLINE_READLINE_H 1
+
 /* Define to 1 if you have the <endian.h> header file. [Python 3] */
 #cmakedefine HAVE_ENDIAN_H 1
 
@@ -393,6 +399,15 @@
 
 /* Define to 1 if you have the `fexecve' function. [Python 3] */
 #cmakedefine HAVE_FEXECVE 1
+
+/* Define if you have the 'ffi_closure_alloc' function. [Python 3.12] */
+#cmakedefine HAVE_FFI_CLOSURE_ALLOC 1
+
+/* Define if you have the 'ffi_prep_cif_var' function. [Python 3.12] */
+#cmakedefine HAVE_FFI_PREP_CIF_VAR 1
+
+/* Define if you have the 'ffi_prep_closure_loc' function. [Python 3.12] */
+#cmakedefine HAVE_FFI_PREP_CLOSURE_LOC 1
 
 /* Define to 1 if you have the `finite' function. [Python <= 3.10] */
 #cmakedefine HAVE_FINITE 1
@@ -768,6 +783,9 @@
 /* Define if compiling using Linux 4.1 or later. [Python 3.9] */
 #cmakedefine HAVE_LINUX_CAN_RAW_JOIN_FILTERS 1
 
+/* Define to 1 if you have the <linux/fs.h> header file. [Python 3.12] */
+#cmakedefine HAVE_LINUX_FS_H 1
+
 /* Define to 1 if you have the <linux/limits.h> header file. [Python 3.11] */
 #cmakedefine HAVE_LINUX_LIMITS_H 1
 
@@ -846,6 +864,9 @@
 /* Define to 1 if you have the `memrchr' function. [Python 3] */
 #cmakedefine HAVE_MEMRCHR 1
 
+/* Define to 1 if you have the <minix/config.h> header file. [Python 3.12] */
+#cmakedefine HAVE_MINIX_CONFIG_H 1
+
 /* Define to 1 if you have the `mkdirat' function. [Python 3] */
 #cmakedefine HAVE_MKDIRAT 1
 
@@ -873,6 +894,9 @@
 /* Define to 1 if you have the `nanosleep' function. [Python 3.11] */
 #cmakedefine HAVE_NANOSLEEP 1
 
+/* Define to 1 if you have the `ncursesw' library. [Python 3.12] */
+#cmakedefine HAVE_NCURSESW 1
+
 /* Define to 1 if you have the <ncurses.h> header file. */
 #cmakedefine HAVE_NCURSES_H 1
 
@@ -893,6 +917,9 @@
 
 /* Define to 1 if you have the <netpacket/packet.h> header file. */
 #cmakedefine HAVE_NETPACKET_PACKET_H 1
+
+/* Define to 1 if you have the <net/ethernet.h> header file. [Python 3.12] */
+#cmakedefine HAVE_NET_ETHERNET_H 1
 
 /* Define to 1 if you have the <net/if.h> header file. [Python 3] */
 #cmakedefine HAVE_NET_IF_H 1
@@ -915,6 +942,9 @@
 
 /* Define if compiling using MacOS X 10.5 SDK or later. [Python <= 3.5] */
 #cmakedefine HAVE_OSX105_SDK 1
+
+/* Define to 1 if you have the <panel.h> header file. [Python 3.12] */
+#cmakedefine HAVE_PANEL_H 1
 
 /* Define to 1 if you have the `pathconf' function. */
 #cmakedefine HAVE_PATHCONF 1
@@ -1014,6 +1044,9 @@
 
 /* Define if the libcrypto has RAND_egd [Python 3, Python <= 3.4] */
 #cmakedefine HAVE_RAND_EGD 1
+
+/* Define to 1 if you have the <readline/readline.h> header file. [Python 3.12] */
+#cmakedefine HAVE_READLINE_READLINE_H 1
 
 /* Define to 1 if you have the `readlink' function. */
 #cmakedefine HAVE_READLINK 1
@@ -1138,6 +1171,9 @@
 /* Define to 1 if you have the `setlocale' function. */
 #cmakedefine HAVE_SETLOCALE 1
 
+/* Define to 1 if you have the `setns' function. [Python 3.12] */
+#cmakedefine HAVE_SETNS 1
+
 /* Define to 1 if you have the `setpgid' function. */
 #cmakedefine HAVE_SETPGID 1
 
@@ -1258,6 +1294,9 @@
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. [Python 3.12] */
+#cmakedefine HAVE_STDIO_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #cmakedefine HAVE_STDLIB_H 1
@@ -1400,6 +1439,9 @@
 /* Define to 1 if you have the <sys/param.h> header file. */
 #cmakedefine HAVE_SYS_PARAM_H 1
 
+/* Define to 1 if you have the <sys/pidfd.h> header file. [Python 3.12] */
+#cmakedefine HAVE_SYS_PIDFD_H 1
+
 /* Define to 1 if you have the <sys/poll.h> header file. */
 #cmakedefine HAVE_SYS_POLL_H 1
 
@@ -1506,6 +1548,9 @@
 /* Define to 1 if you have the `ttyname' function. [Python 3.11] */
 #cmakedefine HAVE_TTYNAME 1
 
+/* Define to 1 if you have the `ttyname_r' function. [Python 3.12] */
+#cmakedefine HAVE_TTYNAME_R 1
+
 /* Define to 1 if you don't have `tm_zone' but do have the external array
    `tzname'. */
 #cmakedefine HAVE_TZNAME 1
@@ -1536,6 +1581,9 @@
 
 /* Define to 1 if you have the `unsetenv' function. [Python <= 3.8] */
 #cmakedefine HAVE_UNSETENV 1
+
+/* Define to 1 if you have the `unshare' function. [Python 3.12] */
+#cmakedefine HAVE_UNSHARE 1
 
 /* Define if you have a useable wchar_t type defined in wchar.h; useable means
    wchar_t must be an unsigned type with at least 16 bits. (see
@@ -1805,7 +1853,7 @@
 #ifndef _GNU_SOURCE
 #cmakedefine _GNU_SOURCE 1
 #endif
-/* Enable threading extensions on Solaris.  */
+/* Enable POSIX-compatible threading on Solaris.  */
 #ifndef _POSIX_PTHREAD_SEMANTICS
 #cmakedefine _POSIX_PTHREAD_SEMANTICS 1
 #endif
@@ -2005,7 +2053,7 @@
 /* Define to `long int' if <sys/types.h> does not define. */
 #cmakedefine off_t @off_t@
 
-/* Define to `int' if <sys/types.h> does not define. */
+/* Define as a signed integer type capable of holding a process identifier. */
 #cmakedefine pid_t @pid_t@
 
 /* Define to empty if the keyword does not work. */

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -944,6 +944,9 @@ add_python_extension(_md5 ${WIN32_BUILTIN}
         $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_hacl/Hacl_Hash_MD5.c>
     INCLUDEDIRS
         $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Modules/_hacl/include>
+    DEFINITIONS
+        $<$<AND:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>,$<BOOL:${UNIX}>>:_BSD_SOURCE>
+        $<$<AND:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>,$<BOOL:${UNIX}>>:_DEFAULT_SOURCE>
 )
 add_python_extension(_sha1 ${WIN32_BUILTIN}
     SOURCES
@@ -951,6 +954,9 @@ add_python_extension(_sha1 ${WIN32_BUILTIN}
         $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_hacl/Hacl_Hash_SHA1.c>
     INCLUDEDIRS
         $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Modules/_hacl/include>
+    DEFINITIONS
+        $<$<AND:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>,$<BOOL:${UNIX}>>:_BSD_SOURCE>
+        $<$<AND:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>,$<BOOL:${UNIX}>>:_DEFAULT_SOURCE>
 )
 
 # Removed in Python 3.12
@@ -976,6 +982,9 @@ add_python_extension(_sha2 ${WIN32_BUILTIN}
         _hacl/Hacl_Hash_SHA2.c
     INCLUDEDIRS
         ${SRC_DIR}/Modules/_hacl/include
+    DEFINITIONS
+        $<$<BOOL:${UNIX}>:_BSD_SOURCE>
+        $<$<BOOL:${UNIX}>:_DEFAULT_SOURCE>
 )
 add_python_extension(_sha3 ${WIN32_BUILTIN}
     REQUIRES
@@ -985,6 +994,9 @@ add_python_extension(_sha3 ${WIN32_BUILTIN}
         $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_hacl/Hacl_Hash_SHA3.c>
     INCLUDEDIRS
         $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Modules/_hacl/include>
+    DEFINITIONS
+        $<$<BOOL:${UNIX}>:_BSD_SOURCE>
+        $<$<BOOL:${UNIX}>:_DEFAULT_SOURCE>
 )
 add_python_extension(_tokenize ALWAYS_BUILTIN
     REQUIRES

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -12,6 +12,10 @@ set(IS_PY_LESS_3_10 0)
 if(PY_VERSION VERSION_LESS "3.10")
     set(IS_PY_LESS_3_10 1)
 endif()
+set(IS_PY_LESS_3_12 0)
+if(PY_VERSION VERSION_LESS "3.12")
+    set(IS_PY_LESS_3_12 1)
+endif()
 
 set(IS_PY3_3_OR_GREATER 0)
 if(PY_VERSION VERSION_GREATER_EQUAL "3.3")
@@ -40,6 +44,10 @@ endif()
 set(IS_PY3_9_OR_GREATER 0)
 if(PY_VERSION VERSION_GREATER_EQUAL "3.9")
     set(IS_PY3_9_OR_GREATER 1)
+endif()
+set(IS_PY3_12_OR_GREATER 0)
+if(PY_VERSION VERSION_GREATER_EQUAL "3.12")
+    set(IS_PY3_12_OR_GREATER 1)
 endif()
 
 add_python_extension(array ${WIN32_BUILTIN} SOURCES arraymodule.c)
@@ -143,6 +151,45 @@ add_python_extension(_struct ${WIN32_BUILTIN} SOURCES _struct.c)
 add_python_extension(_testcapi NEVER_BUILTIN
     SOURCES
         _testcapimodule.c
+
+        # Introduced in Python 3.12
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/abstract.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/buffer.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/bytes.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/code.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/codec.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/complex.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/datetime.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/dict.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/docstring.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/exceptions.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/file.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/float.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/gc.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/getargs.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/heaptype.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/immortal.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/list.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/long.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/mem.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/numbers.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/run.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/set.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/structmember.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/tuple.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/unicode.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/vectorcall.c>
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_testcapi/watchers.c>
+
+        # Introduced in Python 3.12 and removed in 3.13
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/bytearray.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/eval.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/heaptype_relative.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/import.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/pyos.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/pytime.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/sys.c>
+        $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/vectorcall_limited.c>
 )
 
 set(thread_REQUIRES)
@@ -277,6 +324,7 @@ add_python_extension(_blake2 ${WIN32_BUILTIN}
 add_python_extension(_sha3 ${WIN32_BUILTIN}
     REQUIRES
         IS_PY3_6_OR_GREATER
+        IS_PY_LESS_3_12
     SOURCES
         _sha3/sha3module.c
 )
@@ -350,6 +398,14 @@ add_python_extension(_testclinic
         "PY_VERSION VERSION_GREATER_EQUAL 3.10.10"
     SOURCES
         _testclinic.c
+)
+
+# Python 3.12
+add_python_extension(_testsinglephase BUILTIN
+    REQUIRES
+        IS_PY3_12_OR_GREATER
+    SOURCES
+        _testsinglephase.c
 )
 
 # Python interface to subinterpreter C-API.
@@ -473,6 +529,17 @@ if(EXISTS ${module_src})
 endif()
 add_python_extension(_distutils_findvs REQUIRES WIN32 HAS_DISTUTILS_FINDVS_MODULE_SRC SOURCES ${module_src})
 
+add_python_extension(_wmi
+    REQUIRES
+        IS_PY3_12_OR_GREATER
+        WIN32
+    SOURCES
+        ${SRC_DIR}/PC/_wmimodule.cpp
+    LIBRARIES
+        propsys
+        wbemuuid
+)
+
 # Multiprocessing is different on unix and windows
 if(UNIX)
     set(_multiprocessing3_SOURCES )
@@ -527,6 +594,7 @@ if(WIN32)
             ws2_32
             ${M_LIBRARIES}
             $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.8>:iphlpapi>
+            $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:Rpcrt4>
     )
 else()
     add_python_extension(_socket
@@ -560,21 +628,35 @@ if(
     (WIN32 AND PY_VERSION VERSION_GREATER_EQUAL "3.8")
     OR
     (LINUX AND PY_VERSION VERSION_GREATER_EQUAL "3.7")
+    OR
+    (APPLE AND PY_VERSION VERSION_GREATER_EQUAL "3.12")
   )
     # If installed, build ctypes using the system ffi
     # * on Windows for python >= 3.8
     # * on Linux for python >= 3.7
+    # * on macOS for python >= 3.12
     if(NOT USE_SYSTEM_LibFFI)
-        message(AUTHOR_WARNING "Disabling USE_SYSTEM_LibFFI option is *NOT* supported with Python >= 3.8 on windows and with Python >= 3.7 on Linux. Current version is ${PY_VERSION}")
+        message(AUTHOR_WARNING "Disabling USE_SYSTEM_LibFFI option is *NOT* supported with Python >= 3.8 on windows, Python >= 3.7 on Linux, Python >= 3.12 on macOS. Current version is ${PY_VERSION}")
+    endif()
+    set(ctypes_malloc_closure 0)
+    if(APPLE AND PY_VERSION VERSION_GREATER_EQUAL "3.12")
+      set(ctypes_malloc_closure 1)
+    endif()
+    set(_ctypes_REQUIRES)
+    if(PY_VERSION VERSION_GREATER_EQUAL "3.12")
+      list(APPEND _ctypes_REQUIRES HAVE_FFI_CALL)
     endif()
     add_python_extension(_ctypes
         REQUIRES
             LibFFI_INCLUDE_DIR
             LibFFI_LIBRARY
+            ${_ctypes_REQUIRES}
         SOURCES
             ${ctypes_COMMON_SOURCES}
+            $<$<BOOL:${ctypes_malloc_closure}>:_ctypes/malloc_closure.c>
         DEFINITIONS
             Py_BUILD_CORE_MODULE
+            $<$<BOOL:${ctypes_malloc_closure}>:USING_MALLOC_CLOSURE_DOT_C=1>
             # Starting with python/cpython@38f331d4656 ("bpo-45898: Remove duplicate symbols from _ctypes/cfield.c (GH-29791)", 2022-02-24), FFI_BUILDING is removed. Note that while the use of FFI_BUILDING seems
             # to be specific to windows, backward compatibility is maintained defining it for all platforms.
             $<$<VERSION_LESS:${PY_VERSION},3.11>:FFI_BUILDING>
@@ -859,18 +941,68 @@ endif()
 add_python_extension(_md5 ${WIN32_BUILTIN}
     SOURCES
         md5module.c
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_hacl/Hacl_Hash_MD5.c>
+    INCLUDEDIRS
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Modules/_hacl/include>
 )
 add_python_extension(_sha1 ${WIN32_BUILTIN}
     SOURCES
         sha1module.c
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_hacl/Hacl_Hash_SHA1.c>
+    INCLUDEDIRS
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Modules/_hacl/include>
 )
+
+# Removed in Python 3.12
 add_python_extension(_sha256 ${WIN32_BUILTIN}
+    REQUIRES
+        IS_PY_LESS_3_12
     SOURCES
         sha256module.c
 )
 add_python_extension(_sha512 ${WIN32_BUILTIN}
+    REQUIRES
+        IS_PY_LESS_3_12
     SOURCES
         sha512module.c
+)
+
+# Python 3.12
+add_python_extension(_sha2 ${WIN32_BUILTIN}
+    REQUIRES
+        IS_PY3_12_OR_GREATER
+    SOURCES
+        sha2module.c
+        _hacl/Hacl_Hash_SHA2.c
+    INCLUDEDIRS
+        ${SRC_DIR}/Modules/_hacl/include
+)
+add_python_extension(_sha3 ${WIN32_BUILTIN}
+    REQUIRES
+        IS_PY3_12_OR_GREATER
+    SOURCES
+        sha3module.c
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:_hacl/Hacl_Hash_SHA3.c>
+    INCLUDEDIRS
+        $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Modules/_hacl/include>
+)
+add_python_extension(_tokenize ALWAYS_BUILTIN
+    REQUIRES
+        IS_PY3_12_OR_GREATER
+    SOURCES
+        ${SRC_DIR}/Python/Python-tokenize.c
+)
+add_python_extension(_typing ALWAYS_BUILTIN
+    REQUIRES
+        IS_PY3_12_OR_GREATER
+    SOURCES
+        _typingmodule.c
+)
+add_python_extension(_xxinterpchannels ALWAYS_BUILTIN
+    REQUIRES
+        IS_PY3_12_OR_GREATER
+    SOURCES
+        _xxinterpchannelsmodule.c
 )
 
 # Extensions that depend on other libraries

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -119,7 +119,9 @@ set(PARSER_COMMON_SOURCES # Equivalent to POBJS in Makefile.pre
 )
 
 set(OBJECT_COMMON_SOURCES # Equivalent to OBJECT_OBJS in Makefile.pre
-    ${SRC_DIR}/Objects/accu.c
+    # Removed in Python 3.12
+    $<$<VERSION_LESS:${PY_VERSION},3.12>:${SRC_DIR}/Objects/accu.c>
+
     ${SRC_DIR}/Objects/bytesobject.c
     $<$<C_COMPILER_ID:MSVC>:${SRC_DIR}/PC/invalid_parameter_handler.c>
     ${SRC_DIR}/Objects/abstract.c
@@ -176,6 +178,9 @@ set(OBJECT_COMMON_SOURCES # Equivalent to OBJECT_OBJS in Makefile.pre
 
     # Introduced in Python 3.10
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.10>:${SRC_DIR}/Objects/unionobject.c>
+
+    # Introduced in Python 3.12
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Objects/typevarobject.c>
 )
 
 if(CMAKE_C_COMPILER_ID MATCHES GNU)
@@ -295,6 +300,16 @@ set(PYTHON_COMMON_SOURCES
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Python/Python-tokenize.c>
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Python/frame.c>
     $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>:${SRC_DIR}/Python/specialize.c>
+
+    # Introduced in Python 3.12
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/assemble.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/ceval_gil.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/flowgraph.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/instrumentation.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/intrinsics.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/legacy_tracing.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/perf_trampoline.c>
+    $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>:${SRC_DIR}/Python/tracemalloc.c>
 )
 
 if(UNIX)
@@ -426,6 +441,9 @@ configure_file(
 if(WIN32 AND PY_VERSION VERSION_GREATER_EQUAL "3.11")
 set(config_inits "")
 set(minimal_builtin_extensions _codecs _collections _io _imp _sre _thread _tracemalloc _weakref errno faulthandler itertools time)
+if(PY_VERSION VERSION_GREATER_EQUAL "3.12")
+  list(APPEND minimal_builtin_extensions _typing _winapi)
+endif()
 if(WIN32)
     list(APPEND minimal_builtin_extensions nt winreg)
     set(config_inits "${config_inits}/* Define extern variables omitted from minimal builds */\n")
@@ -737,7 +755,7 @@ list(APPEND LIBPYTHON_DEEPFREEZE_SOURCES
     ${SRC_DIR}/Python/deepfreeze/deepfreeze.c
 )
 
-set(DEEPFREEZE_PY ${SRC_DIR}/Tools/scripts/deepfreeze.py)
+set(DEEPFREEZE_PY ${SRC_DIR}/Tools/$<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.12>,build,scripts>/deepfreeze.py)
 
 add_custom_command(
   OUTPUT ${LIBPYTHON_DEEPFREEZE_SOURCES}

--- a/patches/3.12/0001-_bootstrap_python-Fix-execution-on-windows-disabling.patch
+++ b/patches/3.12/0001-_bootstrap_python-Fix-execution-on-windows-disabling.patch
@@ -1,0 +1,51 @@
+From ca2fd1a78562f904f4f5d7046cac9276c2ad2afa Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Tue, 13 May 2025 20:36:35 -0400
+Subject: [PATCH] _bootstrap_python: Fix execution on windows disabling site
+ import
+
+This works around the lack of `sys.winver` attribute addressing the following
+error:
+
+```
+ Generating C:/path/to/Python-3.12.10/Python/deepfreeze/deepfreeze.c
+CUSTOMBUILD : Fatal Python error : init_import_site: Failed to import the site module [C:\path	o\pycbs-3.12-build\CMakeBuild\libpython\libpython-shared.vcxproj]
+  Python runtime state: initialized
+  Traceback (most recent call last):
+    File "C:\path	o\pycbs-3.12-build\Lib\site.py", line 636, in <module>
+      main()
+    File "C:\path	o\pycbs-3.12-build\Lib\site.py", line 622, in main
+      known_paths = addusersitepackages(known_paths)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "C:\path	o\pycbs-3.12-build\Lib\site.py", line 361, in addusersitepackages
+      user_site = getusersitepackages()
+                  ^^^^^^^^^^^^^^^^^^^^^
+    File "C:\path	o\pycbs-3.12-build\Lib\site.py", line 348, in getusersitepackages
+      USER_SITE = _get_path(userbase)
+                  ^^^^^^^^^^^^^^^^^^^
+    File "C:\path	o\pycbs-3.12-build\Lib\site.py", line 313, in _get_path
+      ver_nodot = sys.winver.replace('.', '')
+                  ^^^^^^^^^^
+  AttributeError: module 'sys' has no attribute 'winver'
+```
+---
+ Programs/_bootstrap_python.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Programs/_bootstrap_python.c b/Programs/_bootstrap_python.c
+index 6c388fc7033..edbe2847904 100644
+--- a/Programs/_bootstrap_python.c
++++ b/Programs/_bootstrap_python.c
+@@ -76,6 +76,9 @@ main(int argc, char **argv)
+     // add current script dir to sys.path
+     config.isolated = 0;
+     config.safe_path = 0;
++#ifdef MS_WINDOWS
++    config.site_import = 0;
++#endif
+ 
+ #ifdef MS_WINDOWS
+     status = PyConfig_SetArgv(&config, argc, argv);
+-- 
+2.48.1
+

--- a/patches/3.12/0002-getpath-Update-build-directory-assumptions-based-on-.patch
+++ b/patches/3.12/0002-getpath-Update-build-directory-assumptions-based-on-.patch
@@ -1,0 +1,105 @@
+From b8d5fa3e61e2f1f8d07f8b8291c281cbdd02c4ad Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Date: Fri, 30 May 2025 14:54:08 -0400
+Subject: [PATCH] getpath: Update build directory assumptions based on
+ python-cmake-buildsystem
+
+This ensures the following tests pass:
+- `test_sys` (`SysModuleTest.test_stdlib_dir`)
+- `test_frozen` (`TestFrozen.test_unfrozen_submodule_in_frozen_package`)
+---
+ Lib/test/test_getpath.py | 12 ++++++------
+ Modules/getpath.py       | 10 +++++++---
+ 2 files changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/Lib/test/test_getpath.py b/Lib/test/test_getpath.py
+index b9cbe1d92c4..374bfeef5f9 100644
+--- a/Lib/test/test_getpath.py
++++ b/Lib/test/test_getpath.py
+@@ -304,7 +304,7 @@ def test_buildpath_posix(self):
+         ns.add_known_xfile("/home/cpython/python")
+         ns.add_known_xfile("/usr/local/bin/python")
+         ns.add_known_file("/home/cpython/pybuilddir.txt", ["build/lib.linux-x86_64-9.8"])
+-        ns.add_known_file("/home/cpython/Lib/os.py")
++        ns.add_known_file("/home/cpython/lib/python9.8/os.py")
+         ns.add_known_dir("/home/cpython/lib-dynload")
+         expected = dict(
+             executable="/home/cpython/python",
+@@ -316,7 +316,7 @@ def test_buildpath_posix(self):
+             module_search_paths_set=1,
+             module_search_paths=[
+                 "/usr/local/lib/python98.zip",
+-                "/home/cpython/Lib",
++                "/home/cpython/lib/python9.8",
+                 "/home/cpython/build/lib.linux-x86_64-9.8",
+             ],
+         )
+@@ -492,7 +492,7 @@ def test_symlink_buildpath_posix(self):
+         ns.add_known_link("/linkfrom/python", "/home/cpython/python")
+         ns.add_known_xfile("/usr/local/bin/python")
+         ns.add_known_file("/home/cpython/pybuilddir.txt", ["build/lib.linux-x86_64-9.8"])
+-        ns.add_known_file("/home/cpython/Lib/os.py")
++        ns.add_known_file("/home/cpython/lib/python9.8/os.py")
+         ns.add_known_dir("/home/cpython/lib-dynload")
+         expected = dict(
+             executable="/linkfrom/python",
+@@ -504,7 +504,7 @@ def test_symlink_buildpath_posix(self):
+             module_search_paths_set=1,
+             module_search_paths=[
+                 "/usr/local/lib/python98.zip",
+-                "/home/cpython/Lib",
++                "/home/cpython/lib/python9.8",
+                 "/home/cpython/build/lib.linux-x86_64-9.8",
+             ],
+         )
+@@ -799,7 +799,7 @@ def test_symlink_buildpath_macos(self):
+         ns.add_known_link("/linkfrom/python", "/home/cpython/python")
+         ns.add_known_xfile("/usr/local/bin/python")
+         ns.add_known_file("/home/cpython/pybuilddir.txt", ["build/lib.macos-9.8"])
+-        ns.add_known_file("/home/cpython/Lib/os.py")
++        ns.add_known_file("/home/cpython/lib/python9.8/os.py")
+         ns.add_known_dir("/home/cpython/lib-dynload")
+         expected = dict(
+             executable="/linkfrom/python",
+@@ -811,7 +811,7 @@ def test_symlink_buildpath_macos(self):
+             module_search_paths_set=1,
+             module_search_paths=[
+                 "/usr/local/lib/python98.zip",
+-                "/home/cpython/Lib",
++                "/home/cpython/lib/python9.8",
+                 "/home/cpython/build/lib.macos-9.8",
+             ],
+         )
+diff --git a/Modules/getpath.py b/Modules/getpath.py
+index 9913fcba497..abe87164a4d 100644
+--- a/Modules/getpath.py
++++ b/Modules/getpath.py
+@@ -180,7 +180,7 @@
+     STDLIB_SUBDIR = f'{platlibdir}/python{VERSION_MAJOR}.{VERSION_MINOR}'
+     STDLIB_LANDMARKS = [f'{STDLIB_SUBDIR}/os.py', f'{STDLIB_SUBDIR}/os.pyc']
+     PLATSTDLIB_LANDMARK = f'{platlibdir}/python{VERSION_MAJOR}.{VERSION_MINOR}/lib-dynload'
+-    BUILDSTDLIB_LANDMARKS = ['Lib/os.py']
++    BUILDSTDLIB_LANDMARKS = [f'lib/python{VERSION_MAJOR}.{VERSION_MINOR}/os.py']
+     VENV_LANDMARK = 'pyvenv.cfg'
+     ZIP_LANDMARK = f'{platlibdir}/python{VERSION_MAJOR}{VERSION_MINOR}.zip'
+     DELIM = ':'
+@@ -510,10 +510,14 @@ def search_up(prefix, *landmarks, test=isfile):
+         else:
+             build_stdlib_prefix = search_up(build_prefix, *BUILDSTDLIB_LANDMARKS)
+         # Always use the build prefix for stdlib
++        if os_name == 'nt':
++            lib = 'Lib'
++        else:
++            lib = f'lib/python{VERSION_MAJOR}.{VERSION_MINOR}'
+         if build_stdlib_prefix:
+-            stdlib_dir = joinpath(build_stdlib_prefix, 'Lib')
++            stdlib_dir = joinpath(build_stdlib_prefix, lib)
+         else:
+-            stdlib_dir = joinpath(build_prefix, 'Lib')
++            stdlib_dir = joinpath(build_prefix, lib)
+         # Only use the build prefix for prefix if it hasn't already been set
+         if not prefix:
+             prefix = build_stdlib_prefix
+-- 
+2.48.1
+

--- a/patches/3.12/README.rst
+++ b/patches/3.12/README.rst
@@ -1,0 +1,4 @@
+* ``0001-_bootstrap_python-Fix-execution-on-windows-disabling.patch``: _bootstrap_python: Fix execution on windows disabling site import.
+
+* ``0002-getpath-Update-build-directory-assumptions-based-on-.patch``: getpath: Update build directory assumptions based on
+ python-cmake-buildsystem


### PR DESCRIPTION
* Add checksums for Python 3.12.0 to 3.12.10

* Set default python version to 3.12.10

* Fix windows _bootstrap_python build generating custom "config_minimal.c". This also required adding 3.12 patch to work around the lack of `sys.winver`. See python-cmake-buildsystem/cpython@ca2fd1a7856 ("_bootstrap_python: Fix execution on windows disabling site import", 2025-05-13)

_bootstrap_python:

* Fix windows build updating `config_minimal.c` including `_typing`. Follow-up of 5683458 ("cmake: Fix windows _bootstrap_python build generating custom "config_minimal.c"", 2025-05-13)

ctypes extension:

* Introduce `HAVE_FFI_CALL` set to 1 only if the `ffi_call` symbol is found. This allows to implement the logic similar to the one introduced in autoconf.

* On macOS, the extension requires to be built against system ffi. See python/cpython@2df82db4850 ("gh-100540: Remove obsolete Modules/_ctypes/darwin/ dlfcn shim (GH-100541)", 2022-12-29)

* On macOS, the extension requires to compile `_ctypes/malloc_closure.c` along with setting define `USING_MALLOC_CLOSURE_DOT_C` to `1`

Updated `pyconfig.h.in`:

* Add the following for which there was already a configure check.
  - Headers:
    - `HAVE_EDITLINE_READLINE_H`
    - `HAVE_MINIX_CONFIG_H`
    - `HAVE_PANEL_H`
    - `HAVE_READLINE_READLINE_H`
  - Libraries:
    - `HAVE_NCURSESW`

Updated `pyconfig.h.in` and configure checks:

* Add header checks:
  - `HAVE_LINUX_FS_H`
  - `HAVE_NET_ETHERNET_H`
  - `HAVE_STDIO_H`
  - `HAVE_SYS_PIDFD_H`

* Add symbol checks:
  - `HAVE_FFI_CLOSURE_ALLOC`
  - `HAVE_FFI_PREP_CIF_VAR`
  - `HAVE_FFI_PREP_CLOSURE_LOC`
  - `HAVE_SETNS`
  - `HAVE_TTYNAME_R`
  - `HAVE_UNSHARE`

* Add type checks:
  - `ALIGNOF_MAX_ALIGN_T`

Tests:

* Include CPython patch to update build directory assumptions in `getpath.py` to
  fix `test_frozen` and `test_sys`. See python-cmake-buildsystem/cpython@b8d5fa3e61e ("getpath: Update build directory assumptions based on python-cmake-buildsystem", 2025-05-30)

----------

Working toward addressing:
* #350