### PR TITLE
fix(pyconfig): Fix configuration of RETSIGTYPE

### DIFF
--- a/cmake/config-unix/pyconfig.h.in
+++ b/cmake/config-unix/pyconfig.h.in
@@ -1704,7 +1704,7 @@
 #cmakedefine Py_TRACE_REFS 1
 
 /* assume C89 semantics that RETSIGTYPE is always void */
-#cmakedefine RETSIGTYPE
+#cmakedefine RETSIGTYPE @RETSIGTYPE@
 
 /* Define if setpgrp() must be called as setpgrp(0, 0). */
 #cmakedefine SETPGRP_HAVE_ARG 1


### PR DESCRIPTION
Fix regression introduced in 17a2c25 ("fix(pyconfig): Do not redefine RETSIGTYPE", 2025-05-26) introduced through the following pull request:
* https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/401

----------

Working toward addressing:
* #350

