### PR TITLE
fix: disable vcdiv64.asm on non-x86_64 Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-latest, windows-11-arm]
+        runs-on: [macos-latest]
         python-version: [3.7.17, 3.8.20, 3.9.22, 3.10.17, 3.11.12]
         include:
           - runs-on: macos-latest


### PR DESCRIPTION
Required for building on Windows arm64.

https://github.com/python/cpython/blob/3.12/PCbuild/_decimal.vcxproj#L140-L146