### PR TITLE
chore: Simplify `add_custom_(command|target)` by removing obsolete syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,7 +625,7 @@ endif()
 
 # Add target to run "Argument Clinic" over all source files
 add_custom_target(clinic
-    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:python> ${SRC_DIR}/Tools/clinic/clinic.py --make
+    COMMAND python ${SRC_DIR}/Tools/clinic/clinic.py --make
     DEPENDS python
     WORKING_DIRECTORY ${SRC_DIR}
     COMMENT "Running 'Argument Clinic' over all source files"
@@ -634,12 +634,12 @@ add_custom_target(clinic
 
 # Add target to generate 'Include/graminit.h' and 'Python/graminit.c'
 if(PY_VERSION VERSION_GREATER_EQUAL "3.8")
-    set(generate_graminit_command $<TARGET_FILE:python> -m Parser.pgen)
+    set(generate_graminit_command python -m Parser.pgen)
 else()
-    set(generate_graminit_command $<TARGET_FILE:pgen>)
+    set(generate_graminit_command pgen)
 endif()
 add_custom_target(generate_graminit
-    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${generate_graminit_command}
+    COMMAND ${generate_graminit_command}
         ${SRC_DIR}/Grammar/Grammar
         $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.8>:${SRC_DIR}/Grammar/Tokens>
         ${PROJECT_BINARY_DIR}/CMakeFiles/graminit.h
@@ -693,7 +693,7 @@ endif()
 
 # Add target to generate 'opcode.h' header file
 add_custom_target(generate_opcode_h
-    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:python> ${SRC_DIR}/Tools/scripts/generate_opcode_h.py
+    COMMAND python ${SRC_DIR}/Tools/scripts/generate_opcode_h.py
         ${SRC_DIR}/Lib/opcode.py
         ${PROJECT_BINARY_DIR}/CMakeFiles/opcode.h
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -707,7 +707,7 @@ add_custom_target(generate_opcode_h
 
 # Add target to generate 'Include/Python-ast.h' from 'Python.asdl'
 add_custom_target(generate_python_ast_h
-    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:python> ${SRC_DIR}/Parser/asdl_c.py
+    COMMAND python ${SRC_DIR}/Parser/asdl_c.py
         -h ${SRC_DIR}/Include
         ${SRC_DIR}/Parser/Python.asdl
     DEPENDS python
@@ -718,7 +718,7 @@ add_custom_target(generate_python_ast_h
 
 # Add target to generate 'Python/Python-ast.c' from 'Python.asdl'
 add_custom_target(generate_python_ast_c
-    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:python> ${SRC_DIR}/Parser/asdl_c.py
+    COMMAND python ${SRC_DIR}/Parser/asdl_c.py
         -c ${SRC_DIR}/Python
         ${SRC_DIR}/Parser/Python.asdl
     DEPENDS python

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -499,12 +499,12 @@ set(LIBPYTHON_FROZEN_SOURCES
 add_custom_command(
   OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.8>:importlib._bootstrap_external>
       ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
       ${SRC_DIR}/Python/importlib_external.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       $<$<VERSION_GREATER_EQUAL:${PY_VERSION},3.8>:importlib._bootstrap>
       ${SRC_DIR}/Lib/importlib/_bootstrap.py
       ${SRC_DIR}/Python/importlib.h
@@ -518,7 +518,7 @@ if(PY_VERSION VERSION_GREATER_EQUAL "3.8")
   add_custom_command(
     OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
     COMMAND
-      ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+      _freeze_importlib
         zipimport
         ${SRC_DIR}/Lib/zipimport.py
         ${SRC_DIR}/Python/importlib_zipimport.h
@@ -561,122 +561,122 @@ set(LIBPYTHON_FROZEN_SOURCES
 add_custom_command(
   OUTPUT ${LIBPYTHON_FROZEN_SOURCES}
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       importlib._bootstrap
       ${SRC_DIR}/Lib/importlib/_bootstrap.py
       ${SRC_DIR}/Python/frozen_modules/importlib._bootstrap.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       importlib._bootstrap_external
       ${SRC_DIR}/Lib/importlib/_bootstrap_external.py
       ${SRC_DIR}/Python/frozen_modules/importlib._bootstrap_external.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       zipimport
       ${SRC_DIR}/Lib/zipimport.py
       ${SRC_DIR}/Python/frozen_modules/zipimport.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       abc
       ${SRC_DIR}/Lib/abc.py
       ${SRC_DIR}/Python/frozen_modules/abc.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       codecs
       ${SRC_DIR}/Lib/codecs.py
       ${SRC_DIR}/Python/frozen_modules/codecs.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       io
       ${SRC_DIR}/Lib/io.py
       ${SRC_DIR}/Python/frozen_modules/io.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       _collections_abc
       ${SRC_DIR}/Lib/_collections_abc.py
       ${SRC_DIR}/Python/frozen_modules/_collections_abc.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       _sitebuiltins
       ${SRC_DIR}/Lib/_sitebuiltins.py
       ${SRC_DIR}/Python/frozen_modules/_sitebuiltins.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       genericpath
       ${SRC_DIR}/Lib/genericpath.py
       ${SRC_DIR}/Python/frozen_modules/genericpath.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       ntpath
       ${SRC_DIR}/Lib/ntpath.py
       ${SRC_DIR}/Python/frozen_modules/ntpath.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       posixpath
       ${SRC_DIR}/Lib/posixpath.py
       ${SRC_DIR}/Python/frozen_modules/posixpath.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       os
       ${SRC_DIR}/Lib/os.py
       ${SRC_DIR}/Python/frozen_modules/os.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       site
       ${SRC_DIR}/Lib/site.py
       ${SRC_DIR}/Python/frozen_modules/site.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       stat
       ${SRC_DIR}/Lib/stat.py
       ${SRC_DIR}/Python/frozen_modules/stat.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       importlib.util
       ${SRC_DIR}/Lib/importlib/util.py
       ${SRC_DIR}/Python/frozen_modules/importlib.util.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       importlib.machinery
       ${SRC_DIR}/Lib/importlib/machinery.py
       ${SRC_DIR}/Python/frozen_modules/importlib.machinery.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       runpy
       ${SRC_DIR}/Lib/runpy.py
       ${SRC_DIR}/Python/frozen_modules/runpy.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       __hello__
       ${SRC_DIR}/Lib/__hello__.py
       ${SRC_DIR}/Python/frozen_modules/__hello__.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       __phello__
       ${SRC_DIR}/Lib/__phello__/__init__.py
       ${SRC_DIR}/Python/frozen_modules/__phello__.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       __phello__.ham
       ${SRC_DIR}/Lib/__phello__/ham/__init__.py
       ${SRC_DIR}/Python/frozen_modules/__phello__.ham.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       __phello__.ham.eggs
       ${SRC_DIR}/Lib/__phello__/ham/eggs.py
       ${SRC_DIR}/Python/frozen_modules/__phello__.ham.eggs.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       __phello__.spam
       ${SRC_DIR}/Lib/__phello__/spam.py
       ${SRC_DIR}/Python/frozen_modules/__phello__.spam.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       frozen_only
       ${SRC_DIR}/Tools/freeze/flag.py
       ${SRC_DIR}/Python/frozen_modules/frozen_only.h
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_freeze_importlib>
+    _freeze_importlib
       getpath
       ${SRC_DIR}/Modules/getpath.py
       ${SRC_DIR}/Python/frozen_modules/getpath.h
@@ -742,7 +742,7 @@ set(DEEPFREEZE_PY ${SRC_DIR}/Tools/scripts/deepfreeze.py)
 add_custom_command(
   OUTPUT ${LIBPYTHON_DEEPFREEZE_SOURCES}
   COMMAND
-    ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:_bootstrap_python>
+    _bootstrap_python
       ${DEEPFREEZE_PY}
         "${SRC_DIR}/Python/frozen_modules/importlib._bootstrap.h:importlib._bootstrap"
         "${SRC_DIR}/Python/frozen_modules/importlib._bootstrap_external.h:importlib._bootstrap_external"


### PR DESCRIPTION
Following the CMake minimum required version update from 3.15.6 to 3.20.6, `add_custom_command` and `add_custom_target` now automatically prepend the emulator (from the `CROSSCOMPILING_EMULATOR` property) to the target executable path when cross-compiling.

This eliminates the need for manual command construction previously required to handle emulated targets.

> [!NOTE]
> When the `COMMAND` argument uses constructs like `${CMAKE_COMMAND} -E env` (e.g. in `generate_pegen_metaparser` and `generate_pegen_parse` in the top-level `CMakeLists.txt`), the paths to `CMAKE_CROSSCOMPILING_EMULATOR` and target executable must be explicitly specified.