### PR TITLE
extension_xxlimited: Fix Py_LIMITED_API redefinition warning

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -238,7 +238,7 @@ add_python_extension(_weakref ALWAYS_BUILTIN SOURCES _weakref.c)
 math(EXPR _limited_api_version "${PY_VERSION_MAJOR} * 100 + ${PY_VERSION_MINOR}")
 add_python_extension(xxlimited REQUIRES BUILD_TESTING
     SOURCES xxlimited.c
-    DEFINITIONS Py_LIMITED_API=0x${_limited_api_version}0000
+    DEFINITIONS $<$<VERSION_LESS:${PY_VERSION},3.10>:Py_LIMITED_API=0x${_limited_api_version}0000>
     NO_INSTALL
 )
 add_python_extension(xxsubtype BUILTIN SOURCES xxsubtype.c)


### PR DESCRIPTION
Starting with Python 3.10, the macro `Py_LIMITED_API` is defined in `xxlimited.c`. See python/cpython@240bcf82a11 ("bpo-41111: xxlimited.c defines Py_LIMITED_API (GH-25151)", 2021-04-02)

----------

Working toward addressing:
* #350