### PR TITLE
test: Filter tests based on support.requires(...) and supported resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,9 +801,18 @@ file(MAKE_DIRECTORY "${EXTENSION_BUILD_DIR}")
 install(DIRECTORY DESTINATION ${EXTENSION_INSTALL_DIR})
 
 if(BUILD_TESTING)
-    # Command line option "-l/--findleaks" of regrtest is deprecated since Python 3.7 and
-    # removed in Python 3.11. It is superseded by --fail-env-changed.
-    set(TESTOPTS $<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>,--fail-env-changed,-l> -u network)
+    set(SUPPORTED_TEST_RESOURCES network)
+    message(STATUS "Supported test resources: ${SUPPORTED_TEST_RESOURCES}")
+
+    list(JOIN SUPPORTED_TEST_RESOURCES "," regrtest_resources)
+
+    set(TESTOPTS
+      # Command line option "-l/--findleaks" of regrtest is deprecated since Python 3.7 and
+      # removed in Python 3.11. It is superseded by --fail-env-changed.
+      $<IF:$<VERSION_GREATER_EQUAL:${PY_VERSION},3.11>,--fail-env-changed,-l>
+      # Comma-separated list of words indicating the resources to test
+      -u ${regrtest_resources}
+    )
     set(TESTPROG ${PROJECT_BINARY_DIR}/${PYTHONHOME}/test/regrtest.py)
     set(TESTPYTHONOPTS )
       set(TESTPYTHON $<TARGET_FILE:python> ${TESTPYTHONOPTS})

--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -1,10 +1,53 @@
 file(GLOB filenames "${PROJECT_BINARY_DIR}/${PYTHONHOME}/test/test_*.py")
 list(SORT filenames)
 
+set(unittests)
+set(skipped_unittests)
+
+# Since some tests call "support.requires(...)" spliting its arguments
+# over multiple lines and the current parsing does not support the arguments
+# extraction, the associated resource name is hard-coded below.
+set(test_zipfile64_resource "extralargefile")
+
 foreach(filename IN LISTS filenames)
   get_filename_component(unittest ${filename} NAME_WE)
+
+  set(skip_unittest 0)
+
+  # Match only unindented support.requires(...) calls
+  file(STRINGS "${filename}" matches REGEX "^(support\\.requires|requires)\\([^\\)]*\\)")
+
+  if(matches)  # There are support.requires() calls
+    foreach(match IN LISTS matches)
+      # Extract the FIRST quoted argument only
+      string(REGEX MATCH "['\"]([^'\"]*)['\"]" args "${match}")
+      set(expected_resource ${CMAKE_MATCH_1})
+
+      # if not in SUPPORTED_TEST_RESOURCES, skip
+      if(NOT "${expected_resource}" IN_LIST SUPPORTED_TEST_RESOURCES)
+        set(skip_unittest 1)
+        break()
+      endif()
+    endforeach()
+  endif()
+
+  # Handle hardcoded resource override (e.g., due to unsupported multi-line call)
+  if(DEFINED "${unittest}_resource")
+    set(expected_resource "${${unittest}_resource}")
+    if(NOT "${expected_resource}" IN_LIST SUPPORTED_TEST_RESOURCES)
+      set(skip_unittest 1)
+    endif()
+  endif()
+
+  if(skip_unittest)
+    list(APPEND skipped_unittests ${unittest})
+    message(STATUS "  Ignoring '${unittest}' requiring '${expected_resource}' resource")
+    continue()
+  endif()
+
   list(APPEND unittests ${unittest})
 endforeach()
 
+list(LENGTH skipped_unittests skippedcount)
 list(LENGTH filenames testcount)
-message(STATUS "Discovered ${testcount} tests")
+message(STATUS "Discovered ${testcount} tests (skipping ${skippedcount})")


### PR DESCRIPTION
This update ensures that only tests requiring supported resources are executed. Specifically:

* Introduces `SUPPORTED_TEST_RESOURCES` (defaulting to `network`) and uses it to drive both test filtering and the `-u` option passed to `regrtest.py`.

* Updates `UnitTests.cmake` to parse unindented `support.requires(...)` calls in test scripts, extracting the first argument (i.e., the required resource).

* Skips any test that requires a resource not listed in `SUPPORTED_TEST_RESOURCES`.

* Adds support for hardcoded resource mappings (e.g., for tests like `test_zipfile64` where the `requires(...)` call spans multiple lines).

* Emits informative messages when tests are skipped due to unmet resource requirements.

Example of output for Python 3.11:

```
[...]

-- Supported test resources: network
--   Ignoring 'test_curses' requiring 'curses' resource
--   Ignoring 'test_ossaudiodev' requiring 'audio' resource
--   Ignoring 'test_tix' requiring 'gui' resource
--   Ignoring 'test_tk' requiring 'gui' resource
--   Ignoring 'test_ttk_guionly' requiring 'gui' resource
--   Ignoring 'test_winsound' requiring 'audio' resource
--   Ignoring 'test_zipfile64' requiring 'extralargefile' resource
-- Discovered 407 tests (skipping 7)

[...]
```


----------

Working toward addressing:
* #350