### PR TITLE
extension_testcapi: Ensure `python3.lib` is generated before linking on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,6 +641,8 @@ endif()
 if(WIN32 AND TARGET extension_testcapi)
     set(libpython_output_dir "${PROJECT_BINARY_DIR}/CMakeBuild/libpython/$<CONFIG>")
     target_link_directories(extension_testcapi PRIVATE ${libpython_output_dir})
+    # Ensure import library is generated before linking the extension
+    add_dependencies(extension_testcapi libpython3-shared)
 endif()
 
 # Add target to run "Argument Clinic" over all source files


### PR DESCRIPTION
Follow-up to 5d016e6 ("test_testcapi: Fix build ensuring python3.lib is found", 2025-05-27).

This change adds an explicit dependency on `libpython3-shared` to ensure that `python3.lib` is built before linking `extension_testcapi`, preventing potential link errors due to missing or incomplete import libraries.

--- 

This should address error initially reported in:
* https://github.com/Slicer/Slicer/pull/8466