### PR TITLE
fix: Define PY3_DLLNAME as wide string to fix C4133 warnings

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -374,13 +374,14 @@ add_python_extension(_xxtestfuzz
 )
 
 # Python 3.8
+set(_wide_char_modifier "L")
 add_python_extension(_testinternalcapi
     REQUIRES
         IS_PY3_8_OR_GREATER
     SOURCES
         _testinternalcapi.c
     DEFINITIONS
-        "PY3_DLLNAME=\"python3$<$<CONFIG:Debug>:_d>\""
+        "PY3_DLLNAME=${_wide_char_modifier}\"python3$<$<CONFIG:Debug>:_d>\""
 )
 
 # Python 3.9

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -66,15 +66,14 @@ if(WIN32 AND PY_VERSION VERSION_LESS "3.11")
         set(PYTHONPATH "${PYTHONPATH}${PATHSEP}.\\\\${PYTHONHOME_ESCAPED}\\\\lib-tk")
     endif()
 
-    set(_wide_char_modifier)
-        set(_wide_char_modifier "L")
+    set(_wide_char_modifier "L")
 
     set_property(
         SOURCE ${SRC_DIR}/PC/getpathp.c
         PROPERTY COMPILE_DEFINITIONS
             "LANDMARK=${_wide_char_modifier}\"${PYTHONHOME_ESCAPED}\\\\os.py\""
             "PYTHONPATH=${_wide_char_modifier}\"${PYTHONPATH}\""
-            "PY3_DLLNAME=\"python3$<$<CONFIG:Debug>:_d>\""
+            "PY3_DLLNAME=${_wide_char_modifier}\"python3$<$<CONFIG:Debug>:_d>\""
     )
 endif()
 
@@ -217,10 +216,11 @@ elseif(WIN32)
             Py_ENABLE_SHARED
             MS_DLL_ID="${ms_dll_id}"
         )
+    set(_wide_char_modifier "L")
     set_property(
         SOURCE ${SRC_DIR}/Python/dynload_win.c
         PROPERTY COMPILE_DEFINITIONS
-            "PY3_DLLNAME=\"python3$<$<CONFIG:Debug>:_d>\"" # Python 3.11
+            "PY3_DLLNAME=${_wide_char_modifier}\"python3$<$<CONFIG:Debug>:_d>\"" # Python 3.11
         )
 endif()
 
@@ -341,10 +341,11 @@ endif()
 
 # Introduced in Python 3.10 and removed in Python 3.11
 if(WIN32 AND "${PY_VERSION_MAJOR}.${PY_VERSION_MINOR}" VERSION_EQUAL "3.10")
+    set(_wide_char_modifier "L")
     set_property(
         SOURCE ${SRC_DIR}/Python/pathconfig.c
         PROPERTY COMPILE_DEFINITIONS
-            "PY3_DLLNAME=\"python3$<$<CONFIG:Debug>:_d>\""
+            "PY3_DLLNAME=${_wide_char_modifier}\"python3$<$<CONFIG:Debug>:_d>\""
         )
 endif()
 


### PR DESCRIPTION
Fixes warnings when passing narrow string literals to Windows APIs expecting wide strings:

```
C:\path\to\Python-3.12.10\Python\dynload_win.c(191,27): warning C4133: 'function': incompatible types - from 'char [8]
' to 'const wchar_t *' [C:\path\to\pycbs-3.12-build\CMakeBuild\libpython\libpython-shared.vcxproj]
```

Ensures PY3_DLLNAME is consistently defined with the wide string modifier (`L`) across relevant CMake sections.

----------

Working toward addressing:
* #350