### PR TITLE
Fix `test_venv` on Windows adding support for building python launchers 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,14 @@ python_extract_version_info(
 message(STATUS "PY_VERSION     : ${PY_VERSION}")
 message(STATUS "PY_VERSION_LONG: ${PY_VERSION_LONG}")
 
+# Extract "Field3" value and set variable PY_FIELD3_VALUE
+python_compute_release_field3_value(
+    VERSION_PATCH "${PY_VERSION_PATCH}"
+    RELEASE_LEVEL "${PY_RELEASE_LEVEL}"
+    RELEASE_SERIAL "${PY_RELEASE_SERIAL}"
+)
+message(STATUS "PY_FIELD3_VALUE: ${PY_FIELD3_VALUE}")
+
 # Check version
 if(NOT DEFINED _download_${PY_VERSION_LONG}_md5)
     message(WARNING "warning: selected python version '${PY_VERSION_LONG}' is not tested.")
@@ -859,6 +867,10 @@ if(BUILD_TESTING)
     endfunction()
     add_cmakescript_test(
         python_extract_version_info
+        cmake/PythonExtractVersionInfo.cmake
+        )
+    add_cmakescript_test(
+        python_compute_release_field3_value
         cmake/PythonExtractVersionInfo.cmake
         )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,6 +642,9 @@ add_subdirectory(cmake/tools CMakeBuild/tools)
 if(BUILD_WININST)
     add_subdirectory(cmake/PC/bdist_wininst CMakeBuild/bdist_wininst)
 endif()
+if(WIN32)
+    add_subdirectory(cmake/PC/launcher CMakeBuild/launcher)
+endif()
 
 # Ensure the "_testcapi" extension introduced in Python 3.12 can find
 # find "Python3.lib" as it is specified in "PC/pyconfig." using

--- a/cmake/PC/launcher/CMakeLists.txt
+++ b/cmake/PC/launcher/CMakeLists.txt
@@ -1,0 +1,134 @@
+
+function(_add_executable_without_windows)
+  set(_saved_c_flags "${CMAKE_C_FLAGS}")
+
+  # Workaround the lack of "target_remove_definitions()" CMake command by
+  # forcing flags. Note that attempting to update the COMPILE_DEFINITIONS
+  # target property using get_target_property/set_property does not apply here
+  # as the definition to remove is associated with CMAKE_C_FLAGS cache variable.
+  # See https://gitlab.kitware.com/cmake/cmake/-/issues/19796
+
+  # Remove /D_WINDOWS
+  string(REPLACE "/D_WINDOWS" "" _c_flags "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${_c_flags}" CACHE STRING "CMake C Flags" FORCE)
+
+  add_executable(${ARGN})
+
+  # Restore original flags
+  set(CMAKE_C_FLAGS "${_saved_c_flags}" CACHE STRING "CMake C Flags" FORCE)
+endfunction()
+
+# Install tree directory
+set(LAUNCHER_INSTALL_DIR ${BIN_BUILD_DIR})
+
+# Build tree directory
+set(LAUNCHER_BUILD_DIR ${PROJECT_BINARY_DIR}/${LAUNCHER_INSTALL_DIR})
+
+set(launcher_targets)
+
+set(build_venvlauncher 0)
+if(PY_VERSION VERSION_GREATER_EQUAL "3.3")
+  set(build_venvlauncher 1)
+endif()
+
+if(build_venvlauncher)
+  set(target_sources
+    ${SRC_DIR}/PC/launcher.c
+    ${SRC_DIR}/PC/pylauncher.rc
+  )
+  set(target_include_dirs
+    ${SRC_DIR}/PC/
+  )
+  set(target_libraries
+    version
+  )
+
+  # venvlauncher
+  set(target_name "venvlauncher")
+
+  _add_executable_without_windows(${target_name} ${target_sources})
+  target_include_directories(${target_name} PRIVATE ${target_include_dirs})
+  target_link_libraries(${target_name} PRIVATE ${target_libraries})
+  target_compile_definitions(${target_name}
+    PRIVATE
+      _CONSOLE
+      _UNICODE
+      VENV_REDIRECT
+      PY_ICON # For "PC/pylauncher.rc"
+      FIELD3=${PY_FIELD3_VALUE}
+  )
+  list(APPEND launcher_targets ${target_name})
+
+  # venvwlauncher
+  set(target_name "venvwlauncher")
+
+  add_executable(${target_name} WIN32 ${target_sources})
+  target_include_directories(${target_name} PRIVATE ${target_include_dirs})
+  target_link_libraries(${target_name} PRIVATE ${target_libraries})
+  target_compile_definitions(${target_name}
+    PRIVATE
+      _UNICODE
+      _WINDOWS
+      VENV_REDIRECT
+      PYW_ICON # For "PC/pylauncher.rc"
+      FIELD3=${PY_FIELD3_VALUE}
+  )
+  list(APPEND launcher_targets ${target_name})
+endif()
+
+set(build_pylauncher 0)
+if(PY_VERSION VERSION_GREATER_EQUAL "3.11")
+  set(build_pylauncher 1)
+endif()
+
+if(build_pylauncher)
+  set(target_sources
+    ${SRC_DIR}/PC/launcher2.c
+    ${SRC_DIR}/PC/pylauncher.rc
+  )
+  set(target_include_dirs
+    ${SRC_DIR}/PC/
+  )
+  set(target_libraries
+    pathcch
+    shell32
+  )
+
+  # pylauncher
+  set(target_name "pylauncher")
+
+  _add_executable_without_windows(${target_name} ${target_sources})
+  target_include_directories(${target_name} PRIVATE ${target_include_dirs})
+  target_link_libraries(${target_name} PRIVATE ${target_libraries})
+  target_compile_definitions(${target_name}
+    PRIVATE
+      _CONSOLE
+      _UNICODE
+      FIELD3=${PY_FIELD3_VALUE}
+  )
+  list(APPEND launcher_targets ${target_name})
+
+  # pywlauncher
+  set(target_name "pywlauncher")
+
+  add_executable(${target_name} WIN32 ${target_sources})
+  target_include_directories(${target_name} PRIVATE ${target_include_dirs})
+  target_link_libraries(${target_name} PRIVATE ${target_libraries})
+  target_compile_definitions(${target_name}
+    PRIVATE
+      _UNICODE
+      _WINDOWS
+      FIELD3=${PY_FIELD3_VALUE}
+  )
+
+  list(APPEND launcher_targets ${target_name})
+endif()
+
+if(launcher_targets)
+  set_target_properties(${launcher_targets}
+    PROPERTIES
+      LINK_FLAGS "/MANIFEST:NO"
+      RUNTIME_OUTPUT_DIRECTORY ${LAUNCHER_INSTALL_DIR}
+  )
+  install(TARGETS ${launcher_targets} RUNTIME DESTINATION ${BIN_INSTALL_DIR} COMPONENT Runtime)
+endif()

--- a/cmake/PC/launcher/CMakeLists.txt
+++ b/cmake/PC/launcher/CMakeLists.txt
@@ -1,21 +1,23 @@
 
-function(_add_executable_without_windows)
-  set(_saved_c_flags "${CMAKE_C_FLAGS}")
+function(_add_executable_without_windows target_name)
+  # Work around the lack of a "target_remove_definitions()" CMake command by
+  # explicitly undefining _WINDOWS. The following alternatives are either ineffective
+  # or not applicable:
+  #
+  # (1) Modifying and restoring CMAKE_C_FLAGS does not work reliably, as CMake appears
+  #     to apply cached values during the generation step after the function executes.
+  #
+  # (2) Using get_target_property/set_property to manipulate COMPILE_DEFINITIONS
+  #     is ineffective, since /D_WINDOWS is introduced via CMAKE_C_FLAGS and not
+  #     associated with the target's properties.
+  #
+  # See: https://gitlab.kitware.com/cmake/cmake/-/issues/19796
 
-  # Workaround the lack of "target_remove_definitions()" CMake command by
-  # forcing flags. Note that attempting to update the COMPILE_DEFINITIONS
-  # target property using get_target_property/set_property does not apply here
-  # as the definition to remove is associated with CMAKE_C_FLAGS cache variable.
-  # See https://gitlab.kitware.com/cmake/cmake/-/issues/19796
+  add_executable(${target_name} ${ARGN})
 
-  # Remove /D_WINDOWS
-  string(REPLACE "/D_WINDOWS" "" _c_flags "${CMAKE_C_FLAGS}")
-  set(CMAKE_C_FLAGS "${_c_flags}" CACHE STRING "CMake C Flags" FORCE)
-
-  add_executable(${ARGN})
-
-  # Restore original flags
-  set(CMAKE_C_FLAGS "${_saved_c_flags}" CACHE STRING "CMake C Flags" FORCE)
+  # Note: /U_WINDOWS overrides the implicit /D_WINDOWS flag, resulting in MSVC warning D9025.
+  # This warning is harmless and cannot be suppressed directly.
+  target_compile_options(${target_name} PRIVATE /U_WINDOWS)
 endfunction()
 
 # Install tree directory

--- a/cmake/PC/launcher/CMakeLists.txt
+++ b/cmake/PC/launcher/CMakeLists.txt
@@ -29,7 +29,10 @@ set(LAUNCHER_BUILD_DIR ${PROJECT_BINARY_DIR}/${LAUNCHER_INSTALL_DIR})
 set(launcher_targets)
 
 set(build_venvlauncher 0)
-if(PY_VERSION VERSION_GREATER_EQUAL "3.3")
+# While support for building "venvlauncher" was introduced in Python 3.3,
+# we require at least Python 3.9 to avoid the need to generate "pythonnt_rc.h",
+# which was removed in python/cpython@4efc3360c9a ("bpo-41054: Simplify resource compilation on Windows (GH-21004)", 2020-06-24).
+if(PY_VERSION VERSION_GREATER_EQUAL "3.9")
   set(build_venvlauncher 1)
 endif()
 


### PR DESCRIPTION
## Summary

This pull request adds support for building the following Windows-specific Python launchers:

* `venvlauncher` and `venvwlauncher`. Introduced in Python ≥ 3.3, but only built when Python ≥ 3.9 to simplify resource handling.
* `pylauncher` and `pywlauncher`. Introduced and built when Python ≥ 3.11.

These launchers rely on `launcher.c` and `launcher2.c`, depending on the target. They enable Python-specific runtime behavior for virtual environments and support shebang redirection on Windows.


## Implementation Notes

### `_WINDOWS` Macro Handling

To avoid build issues related to the `_WINDOWS` macro being implicitly defined via `/D_WINDOWS` (e.g., from `CMAKE_C_FLAGS`), we introduce a helper function:

```cmake
_add_executable_without_windows(target_name ...)
```

This function:

* Adds the executable target using `add_executable(...)`
* Explicitly undefines `_WINDOWS` using:

  ```cmake
  target_compile_options(${target_name} PRIVATE /U_WINDOWS)
  ```
* Avoids modifying global variables like `CMAKE_C_FLAGS`, which are unreliable and fragile during CMake generation
* Accepts that the following harmless MSVC warning will be emitted:

  ```
  cl : command line warning D9025: overriding '/D_WINDOWS' with '/U_WINDOWS'
  ```

This prevents incorrect subsystem settings or entry-point mismatches that would otherwise occur if `_WINDOWS` were incorrectly defined, particularly in console-mode launchers.

### Manifest Handling

* Pass `/MANIFEST:NO` to the linker to avoid resource duplication errors, since `pylauncher.rc` already includes an embedded manifest.

### Conditional Launcher Build Logic

* `venvlauncher` and `venvwlauncher` are **only built when `PY_VERSION ≥ 3.9`**.

  * While support for these launchers was introduced in Python 3.3, versions < 3.9 required generating `pythonnt_rc.h`.
  * This requirement was removed in [python/cpython@4efc336](https://github.com/python/cpython/commit/4efc3360c9a)
    *"bpo-41054: Simplify resource compilation on Windows (GH-21004)"*.
  * Restricting to Python ≥ 3.9 simplifies the build and avoids conditional logic for legacy resource files.