### PR TITLE
fix: linking error building `_testcapi` in Python 3.12 #434

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -192,9 +192,7 @@ add_python_extension(_testcapi NEVER_BUILTIN
         $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/sys.c>
         $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/vectorcall_limited.c>
 
-    # TODO: Has limited API in 3.12, but since 3.13 it's no longer limited
-    # and as limited API files moved to new `_testlimitedcapi` module.
-    # https://github.com/python/cpython/blob/3.13/Modules/_testlimitedcapi/heaptype_relative.c
+    # Limited API in 3.12, but in 3.13 all limited API files were moved to `_testlimitedcapi`.
     DEFINITIONS $<$<VERSION_EQUAL:${PY_VERSION},3.12>:Py_LIMITED_API=0x${_limited_api_version}0000>
 )
 

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -195,7 +195,7 @@ add_python_extension(_testcapi NEVER_BUILTIN
     # TODO: Has limited API in 3.12, but since 3.13 it's no longer limited
     # and as limited API files moved to new `_testlimitedcapi` module.
     # https://github.com/python/cpython/blob/3.13/Modules/_testlimitedcapi/heaptype_relative.c
-    DEFINITIONS $<$<VERSION_LESS:${PY_VERSION},3.12>:Py_LIMITED_API=0x${_limited_api_version}0000>
+    DEFINITIONS $<$<VERSION_EQUAL:${PY_VERSION},3.12>:Py_LIMITED_API=0x${_limited_api_version}0000>
 )
 
 set(thread_REQUIRES)

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -49,6 +49,7 @@ set(IS_PY3_12_OR_GREATER 0)
 if(PY_VERSION VERSION_GREATER_EQUAL "3.12")
     set(IS_PY3_12_OR_GREATER 1)
 endif()
+math(EXPR _limited_api_version "${PY_VERSION_MAJOR} * 100 + ${PY_VERSION_MINOR}")
 
 add_python_extension(array ${WIN32_BUILTIN} SOURCES arraymodule.c)
 add_python_extension(audioop ${WIN32_BUILTIN}
@@ -190,6 +191,11 @@ add_python_extension(_testcapi NEVER_BUILTIN
         $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/pytime.c>
         $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/sys.c>
         $<$<VERSION_EQUAL:${PY_VERSION_MAJOR}.${PY_VERSION_MINOR},3.12>:_testcapi/vectorcall_limited.c>
+
+    # TODO: Has limited API in 3.12, but since 3.13 it's no longer limited
+    # and as limited API files moved to new `_testlimitedcapi` module.
+    # https://github.com/python/cpython/blob/3.13/Modules/_testlimitedcapi/heaptype_relative.c
+    DEFINITIONS $<$<VERSION_LESS:${PY_VERSION},3.12>:Py_LIMITED_API=0x${_limited_api_version}0000>
 )
 
 set(thread_REQUIRES)
@@ -282,7 +288,6 @@ add_python_extension(_tracemalloc ALWAYS_BUILTIN
        _tracemalloc.c
 )
 add_python_extension(_weakref ALWAYS_BUILTIN SOURCES _weakref.c)
-math(EXPR _limited_api_version "${PY_VERSION_MAJOR} * 100 + ${PY_VERSION_MINOR}")
 add_python_extension(xxlimited REQUIRES BUILD_TESTING
     SOURCES xxlimited.c
     DEFINITIONS $<$<VERSION_LESS:${PY_VERSION},3.10>:Py_LIMITED_API=0x${_limited_api_version}0000>


### PR DESCRIPTION
Resolves #434.

In 3.12 `_testcapi` now had a file with `Py_LIMITED_API` so it was requiring `python3.lib` to link.

https://github.com/python/cpython/blob/3.12/Modules/_testcapi/heaptype_relative.c

Though issue is resolved, it might be still worth investigating why CI didn't catched that error.

@jcfr 