### PR TITLE
fix(extension_sqlite3): Link required Rpcrt4 on Windows when UUID enabled

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -1141,6 +1141,7 @@ add_python_extension(_sqlite3
         ${SQLite3_INCLUDE_DIRS}
     LIBRARIES
         ${SQLite3_LIBRARIES}
+        $<$<PLATFORM_ID:Windows>:Rpcrt4>  # For supporting when SQLITE_WIN32_USE_UUID is enabled
 )
 if(ENABLE_SQLITE3 AND CMAKE_C_COMPILER_ID MATCHES GNU)
     set_property(SOURCE ${SRC_DIR}/Modules/_sqlite/module.c PROPERTY COMPILE_FLAGS -Wno-deprecated-declarations)


### PR DESCRIPTION
This resolves build issues on the Windows platform as seen below when the passed in sqlite3 was built with SQLITE_WIN32_USE_UUID enabled.

```
26>sqlite3_s.lib(sqlite3.obj) : error LNK2001: unresolved external symbol UuidCreate [C:\S5R4\python-build\CMakeBuild\extensions\extension_sqlite3.vcxproj]
26>sqlite3_s.lib(sqlite3.obj) : error LNK2001: unresolved external symbol UuidCreateSequential [C:\S5R4\python-build\CMakeBuild\extensions\extension_sqlite3.vcxproj]
```